### PR TITLE
Fix Installation Issues with RASCIL and BDSF

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This pipeline serves as the starting point for the SKA Digital Twin Pipeline, wh
 ## Local Installation
 #### Conda
 ```shell
+conda create -n karabo python=3.8
+conda activate karabo
 conda install -c i4ds -c conda-forge karabo-pipeline=0.2.0
 ```
 

--- a/doc/src/Installation.md
+++ b/doc/src/Installation.md
@@ -3,7 +3,7 @@
 ## Conda
 
 We support the installation via the conda package manager.
-Currently, python 3.7 is fully supported.
+Currently, python 3.8 is fully supported.
 
 ```shell
 conda install -c i4ds -c conda-forge karabo-pipeline=0.2.0
@@ -12,7 +12,7 @@ conda install -c i4ds -c conda-forge karabo-pipeline=0.2.0
 Full command sequence for installation may look like this.
 
 ```shell
-conda create -n karabo-env python=3.7
+conda create -n karabo-env python=3.8
 conda activate karabo-env
 # karabo-pipeline
 conda install -c i4ds -c conda-forge karabo-pipeline


### PR DESCRIPTION
Generally the issues have been fixed with updates to the repositories i4ds/bdsf-build and i4ds/rascil-build. 
The bdsf build has been updates so that the import error on importing `from rascil.apps import rascil_imager` no longer fails.
The issue lied in the aotools package, which downgraded upon installation the numpy installation, which then had issues, as the bdsf was installed against a certain numpy instance with boost-numpy. 
Now the bdsf package has different versions for different numpy versions. 

The rascil imager is now running again on python 3.8 (generally python 3.8 is the version we use now)
@Lukas113 please test this. 