### PR TITLE
Updated that the docker images are build only after conda build is finished.

### DIFF
--- a/.github/workflows/build-cli-docker-image.yml
+++ b/.github/workflows/build-cli-docker-image.yml
@@ -1,8 +1,10 @@
 name: CLI Docker
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Conda Build"]
+    types:
+      - completed
 
   workflow_dispatch:
 

--- a/.github/workflows/build-jupyter-docker-image.yml
+++ b/.github/workflows/build-jupyter-docker-image.yml
@@ -1,8 +1,10 @@
 name: Jupyter Docker
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Conda Build"]
+    types:
+      - completed
 
   workflow_dispatch:
 


### PR DESCRIPTION
- The docker images are now build with the released versions of conda (hopefully, this is hard to test).