### PR TITLE
Oskarpy 2.8.3 works again

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           conda config --append channels conda-forge
           conda config --append channels i4ds
+          conda config --append channels nvidia/label/cuda-11.7.0
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Build Conda

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,10 +23,9 @@ requirements:
     - python
     - numpy
     - matplotlib
-    - oskarpy=2.8.0
+    - oskarpy=2.8.3
     - rascil=0.7.0
     - requests
-    - astropy
     - healpy
     - pinocchio # [linux]
     - katbeam

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - matplotlib
     - oskarpy=2.8.3
     - rascil=0.7.0
+    - astropy
     - requests
     - healpy
     - pinocchio # [linux]

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,15 +1,15 @@
 name: karabo_dev_env
 channels:
   - i4ds
+  - nvidia/label/cuda-11.7.0
   - i4ds/label/dev
   - conda-forge
-  - nvidia
   - defaults
 dependencies:
   - oskarpy=2.8.0
   - rascil=0.7.0
   - xarray=2022.3.0 # Issue https://github.com/i4Ds/Karabo-Pipeline/issues/146
-  - astropy
+  - astropy=5.1.1
   - numpy>=1.21
   - dask
   - matplotlib

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -7,14 +7,12 @@ channels:
   - defaults
 dependencies:
   - oskarpy=2.8.3
-  - rascil=0.7.0
-  - xarray=2022.3.0 # Issue https://github.com/i4Ds/Karabo-Pipeline/issues/146
+  - rascil=0.7.dev0
   - numpy>=1.21
   - dask
   - matplotlib
   - healpy
   - requests
-  - astropy
   - pinocchio # [linux]
   - katbeam
   - eidos

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,4 +1,4 @@
-name: karabo_dev_env
+name: karabo_dev_env_GPU
 channels:
   - i4ds
   - nvidia/label/cuda-11.7.0
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - oskarpy=2.8.0
+  - oskarpy=2.8.dev3
   - rascil=0.7.0
   - xarray=2022.3.0 # Issue https://github.com/i4Ds/Karabo-Pipeline/issues/146
   - astropy=5.1.1

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -9,7 +9,6 @@ dependencies:
   - oskarpy=2.8.3
   - rascil=0.7.0
   - xarray=2022.3.0 # Issue https://github.com/i4Ds/Karabo-Pipeline/issues/146
-  - astropy=5.1.1
   - numpy>=1.21
   - dask
   - matplotlib

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,12 +1,12 @@
-name: karabo_dev_env_GPU
+name: karabo_dev_env
 channels:
   - i4ds
-  - nvidia/label/cuda-11.7.0
+  - nvidia/label/cuda-11.7.0 # Here we define the version of CUDA to use
   - i4ds/label/dev
   - conda-forge
   - defaults
 dependencies:
-  - oskarpy=2.8.dev3
+  - oskarpy=2.8.3
   - rascil=0.7.0
   - xarray=2022.3.0 # Issue https://github.com/i4Ds/Karabo-Pipeline/issues/146
   - astropy=5.1.1

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -9,6 +9,7 @@ dependencies:
   - oskarpy=2.8.3
   - rascil=0.7.0
   - numpy>=1.21
+  - astropy
   - dask
   - matplotlib
   - healpy

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -7,7 +7,7 @@ channels:
   - defaults
 dependencies:
   - oskarpy=2.8.3
-  - rascil=0.7.dev0
+  - rascil=0.7.0
   - numpy>=1.21
   - dask
   - matplotlib


### PR DESCRIPTION
- to give a cuda-toolkit version, you cannot do cuda-toolkit=11.7.0 but you need to do it as follows: `conda install -c "nvidia/label/cuda-11.7.0" cuda-toolkit`
- Fixed astropy to a version because 5.2 seems broken.
- Rebuilt oskar without numpy fixing because this caused errors when updating oskar to 2.8.3.