### PR TITLE
removed rel conda label setup and fixed versions in the according .ya…

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -22,9 +22,7 @@ jobs:
         id: channels
         run: |
           KARABO_TAG=${{ steps.get-latest-tag.outputs.tag }}
-          export CHANNEL_LABEL=rel_$(echo $KARABO_TAG | cut -d '.' -f 1-2)
-          echo "label=$CHANNEL_LABEL" >> $GITHUB_OUTPUT
-          conda config --append channels "i4ds/label/$CHANNEL_LABEL"
+          conda config --append channels i4ds
           conda config --append channels nvidia/label/cuda-11.7.0
           conda config --append channels conda-forge
       - name: Build Conda
@@ -33,10 +31,9 @@ jobs:
           cd conda
           KARABO_TAG=${{ steps.get-latest-tag.outputs.tag }}
           export KARABO_VERSION="${KARABO_TAG:1}"
-          export CHANNEL_LABEL=${{ steps.channels.outputs.label }}
           conda mambabuild .
       - name: Publish to Conda
         shell: bash -l {0}
         run: |
           conda activate base
-          anaconda -t ${{ secrets.ANACONDA_SECRET }} upload /opt/conda/conda-bld/linux-64/karabo-pipeline-*.tar.bz2 --label ${{ steps.channels.outputs.label }} --force
+          anaconda -t ${{ secrets.ANACONDA_SECRET }} upload /opt/conda/conda-bld/linux-64/karabo-pipeline-*.tar.bz2 --force

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -21,7 +21,6 @@ jobs:
           conda config --append channels conda-forge
           conda config --append channels nvidia/label/cuda-11.7.0
           conda config --append channels i4ds
-          conda config --append channels i4ds/label/rel_v14
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Build Conda

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../
 
 build:
-  string: {{ CHANNEL_LABEL }}
+  string: {{ KARABO_VERSION }}
 
 requirements:
   build:
@@ -27,13 +27,13 @@ requirements:
     - matplotlib
     - healpy
     - requests
-    - pinocchio
-    - katbeam
-    - eidos
+    - pinocchio=5.0.0
+    - katbeam=0.1.1
+    - eidos=1.1.0
     - libcufft
     - cuda-cudart
     - ska-gridder-nifty-cuda=0.0.11
-    - tools21cm
+    - tools21cm=2.0.2
 
 
 test:

--- a/doc/src/installation_user.md
+++ b/doc/src/installation_user.md
@@ -9,8 +9,6 @@
 ## Install Karabo
 The following steps will install Karabo and its prerequisites (miniconda):
 
-Karabo dependency resolving used to be difficult. The current solution requires to point at a specific release label `-c "i4ds/label/{REL_LABEL}" ` in the `conda install` command. Karabo releases follow the `MAJOR.MINOR.PATCH` versioning. Just replace {REL_LABEL} with the `rel_v{MAJOR}.{MINOR}` of the Karabo version you intend to install. E.g. Karabo `v0.15.0` gets the label `rel_v0.15`. An overview of the Karabo-tags is on our [GitHub Karabo-Pipeline](https://github.com/i4Ds/Karabo-Pipeline/tags).
-
 ```
 wget https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh
 bash Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -b
@@ -21,16 +19,16 @@ conda config --set solver libmamba
 conda update -y -n base -c defaults conda
 conda create -y -n karabo-env python=3.9
 conda activate karabo-env
-conda install -y -c "i4ds/label/{REL_LABEL}" -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline
+conda install -y -c i4ds -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline
 conda clean --all -y
 ```
 
-Karabo releases older than `v0.15.0` are deprecated and therefore we don't guarantee a successful installation. They don't follow the above depicted label convention for `conda install`.
+Karabo releases older than `v0.15.0` are deprecated and therefore we don't guarantee a successful installation.
 
 ## Update to the current Karabo version
 A Karabo installation can be updated the following way:
 ```
-conda update -y -c "i4ds/label/{REL_LABEL}" -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline
+conda update -y -c i4ds -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline
 conda clean --all -y
 ```
 

--- a/docker/user/Dockerfile
+++ b/docker/user/Dockerfile
@@ -11,9 +11,7 @@ RUN apt-get update && apt-get install -y curl && apt-get autoclean && rm -rf /va
 RUN conda update -y conda && \
     conda clean --all --yes && \
     conda install mamba -y -c conda-forge
-# REL_LABEL=rel_v{MAJOR}.{MINOR}, assumption is that `KARABO_TAG` has a leading "v", e.g. v0.15.0
-RUN REL_LABEL=rel_$(echo $KARABO_TAG | cut -d '.' -f 1-2) && \
-    mamba install -y -c "i4ds/label/$REL_LABEL" -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline="${KARABO_TAG:1}"
+RUN mamba install -y -c i4ds -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline="${KARABO_TAG:1}"
 RUN pip install jupyterlab ipykernel
 RUN python -m ipykernel install --user --name=karabo
 RUN mkdir /workspace

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,6 @@
 channels:
-  - i4ds/label/rel_v14
-  - nvidia/label/cuda-11.7.0 # Here we define the version of CUDA to use
+  - i4ds
+  - nvidia/label/cuda-11.7.0
   - conda-forge
 dependencies:
   - python=3.9
@@ -8,14 +8,14 @@ dependencies:
   - rascil=1.0.0
   - numpy=1.22
   - astropy
-  - dask
+  - dask=2022.12.1
   - matplotlib
   - healpy
   - requests
-  - pinocchio
-  - katbeam
-  - eidos
+  - pinocchio=5.0.0
+  - katbeam=0.1.1
+  - eidos=1.1.0
   - libcufft
   - cuda-cudart
   - ska-gridder-nifty-cuda=0.0.11
-  - tools21cm
+  - tools21cm=2.0.2


### PR DESCRIPTION
As discussed with @deiruch this PR removes the `rel_v{MAJOR}.{MINOR}` conda label setup and instead fixes the sensitive conda-packages in the `meta.yaml`.

With this change, the conda-dependencies will come from `-c i4ds`, therefore `main`. This makes installation of karabo easier (no label knowledge for `conda-install` is needed). In addition, we then also won't need a new build conda-package for each release and awkward channel hierarchy or conda-builds in `environment.yaml`. This PR addresses #373 partially.

Sadly this is not tested properly because the release is nigh.  But I am confident (at least to some extend :D ) that it will work.