### PR TITLE
fixed version nifty-gridder

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - healpy
     - requests
     - pinocchio=5.0.0
-    - katbeam=0.1.1
+    - katbeam=0.1.0
     - eidos=1.1.0
     - libcufft
     - cuda-cudart

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - eidos=1.1.0
     - libcufft
     - cuda-cudart
-    - ska-gridder-nifty-cuda=0.0.11
+    - ska-gridder-nifty-cuda=0.3.0
     - tools21cm=2.0.2
 
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,5 +17,5 @@ dependencies:
   - eidos=1.1.0
   - libcufft
   - cuda-cudart
-  - ska-gridder-nifty-cuda=0.0.11
+  - ska-gridder-nifty-cuda=0.3.0
   - tools21cm=2.0.2

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - healpy
   - requests
   - pinocchio=5.0.0
-  - katbeam=0.1.1
+  - katbeam=0.1.0
   - eidos=1.1.0
   - libcufft
   - cuda-cudart


### PR DESCRIPTION
fixed version from `0.0.11` to `0.3.0` because it was not wrongly referenced.