### PR TITLE
Lg 304 codestyle1

### DIFF
--- a/karabo/imaging/image.py
+++ b/karabo/imaging/image.py
@@ -15,6 +15,7 @@ from rascil.apps.imaging_qa.imaging_qa_diagnostics import power_spectrum
 
 from karabo.karabo_resource import KaraboResource
 from karabo.util.FileHandle import FileHandle, check_ending
+from karabo.util.plotting_util import get_slices
 
 # store and restore the previously set matplotlib backend,
 # because rascil sets it to Agg (non-GUI)
@@ -116,14 +117,7 @@ class Image(KaraboResource):
             wcs = WCS(self.header)
             print(wcs)
 
-            slices: List[str] = []
-            for i in range(wcs.pixel_n_dim):
-                if i == 0:
-                    slices.append("x")
-                elif i == 1:
-                    slices.append("y")
-                else:
-                    slices.append(0)  # type: ignore
+            slices = get_slices(wcs=wcs)
 
             # create dummy xlim or ylim if only one is set for conversion
             xlim_reset, ylim_reset = False, False

--- a/karabo/simulation/interferometer.py
+++ b/karabo/simulation/interferometer.py
@@ -4,9 +4,11 @@ import os
 import sys
 from copy import deepcopy
 from datetime import timedelta
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
+import numpy as np
 import oskar
+from numpy.typing import NDArray
 
 from karabo.simulation.beam import BeamPattern
 from karabo.simulation.observation import Observation, ObservationLong
@@ -352,6 +354,52 @@ class InterferometerSimulation:
         except BaseException as exp:
             # self.vis_path = vis_path_long
             raise exp
+
+    def simulate_foreground_vis(
+        self,
+        telescope: Telescope,
+        foreground: SkyModel,
+        foreground_observation: Observation,
+        foreground_vis_file: str,
+        write_ms: bool,
+        foreground_ms_file: str,
+    ) -> Tuple[
+        Visibility,
+        List[NDArray[np.complex64]],
+        oskar.VisHeader,
+        oskar.Binary,
+        oskar.VisBlock,
+        NDArray[np.float32],
+        NDArray[np.float32],
+        NDArray[np.float32],
+    ]:
+        """
+        Simulates foreground sources
+        """
+        print("### Simulating foreground source....")
+        visibility = self.run_simulation(telescope, foreground, foreground_observation)
+        (fg_header, fg_handle) = oskar.VisHeader.read(foreground_vis_file)
+        foreground_cross_correlation = [0.0] * fg_header.num_blocks
+        # fg_max_channel=fg_header.max_channels_per_block;
+        for i in range(fg_header.num_blocks):
+            fg_block = oskar.VisBlock.create_from_header(fg_header)
+            fg_block.read(fg_header, fg_handle, i)
+            foreground_cross_correlation[i] = fg_block.cross_correlations()
+        ff_uu = fg_block.baseline_uu_metres()
+        ff_vv = fg_block.baseline_vv_metres()
+        ff_ww = fg_block.baseline_ww_metres()
+        if write_ms:
+            visibility.write_to_file(foreground_ms_file)
+        return (
+            visibility,
+            foreground_cross_correlation,
+            fg_header,
+            fg_handle,
+            fg_block,
+            ff_uu,
+            ff_vv,
+            ff_ww,
+        )
 
     def yes_double_precision(self):
         if self.precision == "single":

--- a/karabo/simulation/sky_model.py
+++ b/karabo/simulation/sky_model.py
@@ -4,11 +4,10 @@ import copy
 import enum
 import logging
 import math
-from typing import Any, Callable, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, List, Literal, Optional, Tuple, Union, cast
 from warnings import warn
 
 import matplotlib.pyplot as plt
-import numpy
 import numpy as np
 import oskar
 import pandas as pd
@@ -25,6 +24,7 @@ from karabo.data.external_data import (
 from karabo.error import KaraboError
 from karabo.util.hdf5_util import convert_healpix_2_radec, get_healpix_image
 from karabo.util.math_util import get_poisson_disk_sky
+from karabo.util.my_types import FloatLike, NPBroadcType
 from karabo.util.plotting_util import get_slices
 from karabo.warning import KaraboWarning
 
@@ -50,6 +50,9 @@ GLEAM_freq = Literal[
     220,
     227,
 ]
+
+SkySourcesType = Union[NDArray[np.float_], NDArray[np.object_]]
+SetSkyItemType = Union[NPBroadcType, str]
 
 
 class Polarisation(enum.Enum):
@@ -82,11 +85,12 @@ class SkyModel:
 
     """
 
+    SOURCES_COLS = 13
+
     def __init__(
         self,
-        sources: Optional[NDArray[Any]] = None,
+        sources: Optional[SkySourcesType] = None,
         wcs: Optional[WCS] = None,
-        nside: int = 0,
     ) -> None:
         """
         Initialization of a new SkyModel
@@ -94,24 +98,21 @@ class SkyModel:
         :param sources: Adds point sources
         :param wcs: world coordinate system
         """
-        self.num_sources = 0
-        self.shape = (0, 0)
-        self.sources = None
+        self.sources: Optional[SkySourcesType] = None
         self.wcs = wcs
-        self.sources_m = 13
         if sources is not None:
             self.add_point_sources(sources)
 
-    def __get_empty_sources(self, n_sources: int) -> NDArray[Any]:
+    def __get_empty_sources(self, n_sources: int) -> SkySourcesType:
         empty_sources = np.hstack(
             (
-                np.zeros((n_sources, self.sources_m - 1)),
+                np.zeros((n_sources, SkyModel.SOURCES_COLS - 1)),
                 np.array([[None] * n_sources]).reshape(-1, 1),
             )
         )
         return empty_sources
 
-    def add_point_sources(self, sources: NDArray[Any]) -> None:
+    def add_point_sources(self, sources: SkySourcesType) -> None:
         """
         Add new point sources to the sky model.
 
@@ -134,21 +135,32 @@ class SkyModel:
             - [12] source id (object): defaults to None
 
         """
-        if len(sources.shape) > 2:
-            return
-        if 2 < sources.shape[1] < self.sources_m + 1:
-            if sources.shape[1] < self.sources_m:
-                # if some elements are missing,
-                # fill them up with zeros except `source_id`
-                missing_shape = self.sources_m - sources.shape[1]
-                fill = self.__get_empty_sources(sources.shape[0])
-                fill[:, :-missing_shape] = sources
-                sources = fill
-            if self.sources is not None:
-                self.sources = np.vstack((self.sources, sources))
-            else:
-                self.sources = sources
-            self.__update_sky_model()
+        if len(sources.shape) != 2:
+            raise ValueError(
+                "`sources` must be 2-dimensional but "
+                + f"is {len(sources.shape)}-dimensional."
+            )
+        if sources.shape[1] < 3:
+            raise ValueError(
+                "`sources` requires min 3 cols: `right_ascension`, "
+                + "`declination` and `stokes I Flux`."
+            )
+        if sources.shape[1] > SkyModel.SOURCES_COLS:
+            raise ValueError(
+                f"Max cols of `sources` is {SkyModel.SOURCES_COLS} "
+                + f"but got {sources.shape[1]}."
+            )
+        if sources.shape[1] < SkyModel.SOURCES_COLS:
+            # if some elements are missing,
+            # fill them up with zeros except `source_id`
+            missing_shape = SkyModel.SOURCES_COLS - sources.shape[1]
+            fill = self.__get_empty_sources(sources.shape[0])
+            fill[:, :-missing_shape] = sources
+            sources = fill
+        if self.sources is not None:
+            self.sources = np.vstack((self.sources, sources))  # type: ignore
+        else:
+            self.sources = sources
 
     def add_point_source(
         self,
@@ -165,7 +177,7 @@ class SkyModel:
         minor_axis_FWHM: float = 0,
         position_angle: float = 0,
         source_id: Optional[object] = None,
-    ):
+    ) -> None:
         """
         Add a single new point source to the sky model.
 
@@ -201,13 +213,12 @@ class SkyModel:
                     source_id,
                 ]
             ],
-            dtype=object,
+            dtype=np.object_,
         )
         if self.sources is not None:
-            self.sources = np.vstack(self.sources, new_sources)  # pyright: ignore
+            self.sources = np.vstack(self.sources, new_sources)  # type: ignore
         else:
             self.sources = new_sources
-        self.__update_sky_model()
 
     def write_to_file(self, path: str) -> None:
         self.save_sky_model_as_csv(path)
@@ -265,7 +276,7 @@ class SkyModel:
         sky = SkyModel(sources)
         return sky
 
-    def to_array(self, with_obj_ids: bool = False) -> NDArray[Any]:
+    def to_array(self, with_obj_ids: bool = False) -> SkySourcesType:
         """
         Gets the sources as np.ndarray
 
@@ -273,10 +284,14 @@ class SkyModel:
 
         :return: the sources of the SkyModel as np.ndarray
         """
+        if self.sources is None:
+            raise KaraboError(
+                "`sources` is None, add sources before calling `to_array`."
+            )
         if with_obj_ids:
-            return self[:]  # pyright: ignore
+            return self.sources
         else:
-            return self[:, :-1]  # pyright: ignore
+            return self.sources[:, :-1]
 
     def filter_by_radius(
         self,
@@ -298,6 +313,10 @@ class SkyModel:
         :return sky: Filtered copy of the sky
         """
         copied_sky = copy.deepcopy(self)
+        if copied_sky.sources is None:
+            raise KaraboError(
+                "`sources` is None, add sources before calling `filter_by_radius`."
+            )
         inner_circle = SphericalCircle(
             (ra0_deg * u.deg, dec0_deg * u.deg),
             inner_radius_deg * u.deg,  # pyright: ignore
@@ -311,7 +330,6 @@ class SkyModel:
         filtered_sources = np.array(outer_sources - inner_sources, dtype="bool")
         filtered_sources_idxs = np.where(filtered_sources == True)[0]  # noqa
         copied_sky.sources = copied_sky.sources[filtered_sources_idxs]
-        copied_sky.__update_sky_model()
 
         if indices is True:
             return copied_sky, filtered_sources_idxs
@@ -322,38 +340,50 @@ class SkyModel:
         self,
         min_flux_jy: float,
         max_flux_jy: float,
-    ) -> None:
+    ) -> SkyModel:
         """
         Filters the sky using the Stokes-I-flux
         Values outside the range are removed
 
         :param min_flux_jy: Minimum flux in Jy
         :param max_flux_jy: Maximum flux in Jy
+        :return sky: Filtered copy of the sky
         """
-        stokes_I_flux = self[:, 2]
+        copied_sky = copy.deepcopy(self)
+        if copied_sky.sources is None:
+            raise KaraboError(
+                "`sources` is None, add sources before calling `filter_by_flux`."
+            )
+        stokes_I_flux = copied_sky[:, 2]
         filtered_sources_idxs = np.where(
             np.logical_and(stokes_I_flux <= max_flux_jy, stokes_I_flux >= min_flux_jy)
         )[0]
-        self.sources = self.sources[filtered_sources_idxs]
-        self.__update_sky_model()
+        copied_sky.sources = copied_sky.sources[filtered_sources_idxs]
+        return copied_sky
 
     def filter_by_frequency(
         self,
         min_freq: float,
         max_freq: float,
-    ) -> None:
+    ) -> SkyModel:
         """
         Filters the sky using the referency frequency in Hz
 
         :param min_freq: Minimum frequency in Hz
         :param max_freq: Maximum frequency in Hz
+        :return sky: Filtered copy of the sky
         """
-        freq = self[:, 6]
+        copied_sky = copy.deepcopy(self)
+        if copied_sky.sources is None:
+            raise KaraboError(
+                "`sources` is None, add sources before calling `filter_by_frequency`."
+            )
+        freq = copied_sky[:, 6]
         filtered_sources_idxs = np.where(
             np.logical_and(freq <= max_freq, freq >= min_freq)
         )[0]
-        self.sources = self.sources[filtered_sources_idxs]
-        self.__update_sky_model()
+        copied_sky.sources = copied_sky.sources[filtered_sources_idxs]
+        return copied_sky
 
     def get_wcs(self) -> WCS:
         """
@@ -414,14 +444,14 @@ class SkyModel:
         title: Optional[str] = None,
         xlabel: Optional[str] = None,
         ylabel: Optional[str] = None,
-        cfun: Optional[Callable] = np.log10,
+        cfun: Optional[Callable[..., NPBroadcType]] = np.log10,
         cmap: Optional[str] = "plasma",
         cbar_label: Optional[str] = None,
         with_labels: bool = False,
         wcs: Optional[WCS] = None,
         wcs_enabled: bool = True,
         filename: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         A scatter plot of the `SkyModel` (self) where the sources
@@ -447,16 +477,12 @@ class SkyModel:
         :param kwargs: matplotlib kwargs for scatter & Collections, e.g. customize `s`,
                        `vmin` or `vmax`
         """
-        if wcs is None and wcs_enabled:
-            wcs = self.setup_default_wcs(phase_center)
         if wcs_enabled:
+            if wcs is None:
+                wcs = self.setup_default_wcs(phase_center)
             px, py = wcs.wcs_world2pix(
                 self[:, 0], self[:, 1], 0
             )  # ra-dec transformation
-        else:
-            px, py = self[:, 0], self[:, 1]
-
-        if wcs_enabled:  # create dummy xlim or ylim if only one is set for conversion
             xlim_reset, ylim_reset = False, False
             if xlim is None and ylim is not None:
                 xlim = (-1, 1)
@@ -470,29 +496,31 @@ class SkyModel:
                 xlim = None
             if ylim_reset:
                 ylim = None
+        else:
+            px, py = self[:, 0], self[:, 1]
 
         flux = None
         if cmap is not None:
             flux = self[:, flux_idx]
-            if cfun in [np.log10, np.log] and any(flux <= 0):
-                warn(
-                    KaraboWarning(
-                        "Warning: flux with value <= 0 found, setting "
-                        "those to np.nan to avoid "
-                        "logarithmic errors (only affects the colorbar)"
-                    )
-                )
-
-                flux = np.where(flux > 0, flux, np.nan)
             if cfun is not None:
-                flux = cfun(flux)
+                if cfun in [np.log10, np.log] and any(flux <= 0):
+                    warn(
+                        KaraboWarning(
+                            "Warning: flux with value <= 0 found, setting "
+                            "those to np.nan to avoid "
+                            "logarithmic errors (only affects the colorbar)"
+                        )
+                    )
+
+                    flux = np.where(flux > 0, flux, np.nan)
+                flux = cfun(flux)  # type: ignore
 
         # handle matplotlib kwargs
         # not set as normal args because default assignment depends on args
         if "vmin" not in kwargs:
-            kwargs["vmin"] = np.nanmin(flux)
+            kwargs["vmin"] = np.nanmin(flux)  # type: ignore
         if "vmax" not in kwargs:
-            kwargs["vmax"] = np.nanmax(flux)
+            kwargs["vmax"] = np.nanmax(flux)  # type: ignore
 
         if wcs_enabled:
             slices = get_slices(wcs)
@@ -535,7 +563,7 @@ class SkyModel:
         if isinstance(filename, str):
             fig.savefig(fname=filename)
 
-    def get_OSKAR_sky(self, precision: Any = "double") -> oskar.Sky:
+    def get_OSKAR_sky(self, precision: str = "double") -> oskar.Sky:
         """
         Get OSKAR sky model object from the defined Sky Model
 
@@ -546,7 +574,7 @@ class SkyModel:
     @staticmethod
     def read_healpix_file_to_sky_model_array(
         file: str, channel: int, polarisation: Polarisation
-    ) -> Tuple[NDArray[np.float64], int]:
+    ) -> Tuple[NDArray[np.float_], int]:
         """
         Read a healpix file in hdf5 format.
         The file should have the map keywords:
@@ -562,14 +590,22 @@ class SkyModel:
         ra, dec, nside = convert_healpix_2_radec(filtered)
         return np.vstack((ra, dec, filtered)).transpose(), nside
 
-    def __update_sky_model(self) -> None:
-        """
-        Updates instance variables of the SkyModel
-        """
-        self.num_sources = self.sources.shape[0]
-        self.shape = self.sources.shape
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        if self.sources is None:
+            raise AttributeError(
+                "`sources` is None and therefore has no `shape` attribute."
+            )
+        return self.sources.shape
 
-    def __getitem__(self, key):
+    @property
+    def num_sources(self) -> int:
+        if self.sources is None:
+            return 0
+        else:
+            return self.shape[0]
+
+    def __getitem__(self, key: Any) -> SkySourcesType:
         """
         Allows to get access to self.sources in an np.ndarray like manner
         If casts the selected array/scalar to float64 if possible
@@ -579,14 +615,16 @@ class SkyModel:
 
         :return: sliced self.sources
         """
-        sources = self.sources[key]
+        if self.sources is None:
+            raise AttributeError("`sources` is None and therefore can't be accessed.")
+        sources = cast(SkySourcesType, self.sources[key])
         try:
-            sources = np.float64(sources)
+            sources = sources.astype(np.float64)
         except ValueError:
             pass  # nothing toDo here
         return sources
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Any, value: SetSkyItemType) -> None:
         """
         Allows to set values in an np.ndarray like manner
 
@@ -594,10 +632,12 @@ class SkyModel:
         :param value: values to store
         """
         if self.sources is None:
-            self.sources = self.__get_empty_sources(len(value))
-        self.sources[key] = value
+            value_ = cast(SkySourcesType, value)
+            self.add_point_sources(sources=value_)
+        else:
+            self.sources[key] = value
 
-    def save_sky_model_as_csv(self, path: str):
+    def save_sky_model_as_csv(self, path: str) -> None:
         """
         Save source array into a csv.
         :param path: path to save the csv file in.
@@ -627,20 +667,24 @@ class SkyModel:
         path: str,
         cols: List[int] = [0, 1, 2, 3, 4, 5, 6, 7],
     ) -> None:
-        numpy.savetxt(path, self.sources[:, cols])
+        if self.sources is None:
+            raise AttributeError("Can't save sky-model because `sources` is None.")
+        np.savetxt(path, self.sources[:, cols])
 
     @staticmethod
-    def __convert_ra_dec_to_cartesian(ra: float, dec: float) -> float:
+    def __convert_ra_dec_to_cartesian(ra: float, dec: float) -> NDArray[np.float_]:
         x = math.cos(math.radians(ra)) * math.cos(math.radians(dec))
         y = math.sin(math.radians(ra)) * math.cos(math.radians(dec))
         z = math.sin(math.radians(dec))
         r = np.array([x, y, z])
-        norm = np.linalg.norm(r)
+        norm = cast(np.float_, np.linalg.norm(r))
         if norm == 0:
             return r
         return r / norm
 
-    def get_cartesian_sky(self) -> NDArray[np.float64]:
+    def get_cartesian_sky(self) -> NDArray[np.float_]:
+        if self.sources is None:
+            raise AttributeError("Can't create cartesian-sky when `sources` is None.")
         cartesian_sky = np.squeeze(
             np.apply_along_axis(
                 lambda row: [
@@ -748,7 +792,7 @@ class SkyModel:
                 np.zeros(ra.shape[0]),
                 [ref_freq] * ra.shape[0],
             )
-        ).astype("float64")
+        ).astype(np.float64)
         sky = SkyModel(sky_array)
         # major axis FWHM, minor axis FWHM, position angle, object id
         sky[:, [9, 10, 11, 12]] = df_mightee[["IM_MAJ", "IM_MIN", "IM_PA", "NAME"]]
@@ -756,10 +800,10 @@ class SkyModel:
 
     @staticmethod
     def get_random_poisson_disk_sky(
-        min_size: Tuple[float, float],
-        max_size: Tuple[float, float],
-        flux_min: float,
-        flux_max: float,
+        min_size: Tuple[FloatLike, FloatLike],
+        max_size: Tuple[FloatLike, FloatLike],
+        flux_min: FloatLike,
+        flux_max: FloatLike,
         r: int = 3,
     ) -> SkyModel:
         sky_array = get_poisson_disk_sky(min_size, max_size, flux_min, flux_max, r)

--- a/karabo/simulation/visibility.py
+++ b/karabo/simulation/visibility.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 import os.path
 import shutil
+from typing import List
 
 import numpy as np
 import oskar
@@ -10,7 +13,7 @@ from karabo.util.FileHandle import FileHandle
 
 
 class Visibility(KaraboResource):
-    def __init__(self):
+    def __init__(self) -> None:
         self.file = FileHandle(is_dir=True, suffix=".ms")
 
     def write_to_file(self, path: str) -> None:
@@ -19,15 +22,17 @@ class Visibility(KaraboResource):
         shutil.copytree(self.file.path, path)
 
     @staticmethod
-    def read_from_file(path: str) -> any:
+    def read_from_file(path: str) -> Visibility:
         file = FileHandle(path, is_dir=True)
         vis = Visibility()
         vis.file = file
         return vis
 
     def combine_spectral_foreground_vis(
-        foreground_vis_file, spectral_vis_output, combined_vis_filepath
-    ):
+        foreground_vis_file: str,
+        spectral_vis_output: List[str],
+        combined_vis_filepath: str,
+    ) -> None:
         """
         This function combines the visibilities of foreground and spectral lines
         Inputs: foreground visibility file, list of spectral line vis files,
@@ -114,45 +119,6 @@ class Visibility(KaraboResource):
             fg_header.num_channels_total,
             fg_block.num_baselines,
             fcc_array,
-        )
-
-    def simulate_foreground_vis(
-        simulation,
-        telescope,
-        foreground,
-        foreground_observation,
-        foreground_vis_file,
-        write_ms,
-        foreground_ms_file,
-    ):
-        """
-        Simulates foreground sources
-        """
-        print("### Simulating foreground source....")
-        visibility = simulation.run_simulation(
-            telescope, foreground, foreground_observation
-        )
-        (fg_header, fg_handle) = oskar.VisHeader.read(foreground_vis_file)
-        foreground_cross_correlation = [0] * fg_header.num_blocks
-        # fg_max_channel=fg_header.max_channels_per_block;
-        for i in range(fg_header.num_blocks):
-            fg_block = oskar.VisBlock.create_from_header(fg_header)
-            fg_block.read(fg_header, fg_handle, i)
-            foreground_cross_correlation[i] = fg_block.cross_correlations()
-        ff_uu = fg_block.baseline_uu_metres()
-        ff_vv = fg_block.baseline_vv_metres()
-        ff_ww = fg_block.baseline_ww_metres()
-        if write_ms:
-            visibility.write_to_file(foreground_ms_file)
-        return (
-            visibility,
-            foreground_cross_correlation,
-            fg_header,
-            fg_handle,
-            fg_block,
-            ff_uu,
-            ff_vv,
-            ff_ww,
         )
 
     @staticmethod

--- a/karabo/simulation/visibility.py
+++ b/karabo/simulation/visibility.py
@@ -139,26 +139,26 @@ class Visibility(KaraboResource):
             day_comb: bool,
         """
         print("### Combining the visibilities for ", visiblity_files)
-        out_vis = [0] * number_of_days
-        uui = [0] * number_of_days
-        vvi = [0] * number_of_days
-        wwi = [0] * number_of_days
-        time_start = [0] * number_of_days
-        time_inc = [0] * number_of_days
-        time_ave = [0] * number_of_days
-        # for j in tqdm(range(number_of_days)):
+
+        out_vis: List[NDArray[np.complex_]] = list()
+        uui: List[NDArray[np.float_]] = list()
+        vvi: List[NDArray[np.float_]] = list()
+        wwi: List[NDArray[np.float_]] = list()
+        time_start = list()
+        time_inc = list()
+        time_ave = list()
         for j in range(number_of_days):
             (header, handle) = oskar.VisHeader.read(visiblity_files[j])
             block = oskar.VisBlock.create_from_header(header)
             for k in range(header.num_blocks):
                 block.read(header, handle, k)
-            out_vis[j] = block.cross_correlations()
-            uui[j] = block.baseline_uu_metres()
-            vvi[j] = block.baseline_vv_metres()
-            wwi[j] = block.baseline_ww_metres()
-            time_inc[j] = header.time_inc_sec
-            time_start[j] = header.time_start_mjd_utc
-            time_ave[j] = header.get_time_average_sec()
+            out_vis.append(block.cross_correlations())
+            uui.append(block.baseline_uu_metres())
+            vvi.append(block.baseline_vv_metres())
+            wwi.append(block.baseline_ww_metres())
+            time_inc.append(header.time_inc_sec)
+            time_start.append(header.time_start_mjd_utc)
+            time_ave.append(header.get_time_average_sec())
             print(uui[j].shape, out_vis[j].shape, number_of_days)
         # uushape = uu.shape
         # uu = uu.reshape(uushape[0], uushape[1] * uushape[2])
@@ -227,7 +227,7 @@ class Visibility(KaraboResource):
             uuf = np.array(uui).reshape(us[0] * us[1], us[2])
             vvf = np.array(vvi).reshape(us[0] * us[1], us[2])
             wwf = np.array(wwi).reshape(us[0] * us[1], us[2])
-            out_vis = np.array(out_vis).reshape(
+            out_vis_reshaped = np.array(out_vis).reshape(
                 outs[0] * outs[1], outs[2], outs[3], outs[4]
             )
             for t in range(num_times):
@@ -249,5 +249,9 @@ class Visibility(KaraboResource):
                     time_stamp,
                 )
                 ms.write_vis(
-                    start_row, 0, block.num_channels, block.num_baselines, out_vis[t]
+                    start_row,
+                    0,
+                    block.num_channels,
+                    block.num_baselines,
+                    out_vis_reshaped[t],
                 )

--- a/karabo/test/test_skymodel.py
+++ b/karabo/test/test_skymodel.py
@@ -93,7 +93,7 @@ class TestSkyModel(unittest.TestCase):
             0,
             Polarisation.STOKES_I,
         )
-        sky = SkyModel(source_array, nside=nside)
+        sky = SkyModel(source_array)
         sky.explore_sky([250, -80])
 
     def test_get_poisson_sky(self):

--- a/karabo/test/test_spectral_line.py
+++ b/karabo/test/test_spectral_line.py
@@ -161,8 +161,7 @@ class TestSystemNoise(unittest.TestCase):
             ff_uu,
             ff_vv,
             ff_ww,
-        ) = Visibility.simulate_foreground_vis(
-            simulation,
+        ) = simulation.simulate_foreground_vis(
             telescope,
             foreground,
             foreground_observation,

--- a/karabo/util/data_util.py
+++ b/karabo/util/data_util.py
@@ -7,7 +7,7 @@ from numpy.typing import NDArray
 from scipy.special import wofz
 
 import karabo
-from karabo.util.my_types import NPInp, NPOutp
+from karabo.util.my_types import NPBroadcType
 
 
 def get_module_absolute_path() -> str:
@@ -56,29 +56,29 @@ def full_getter(self: object) -> Dict[str, Any]:
 
 
 def Gauss(
-    x: NPInp,
-    x0: NPInp,
-    y0: NPInp,
-    a: NPInp,
-    sigma: NPInp,
-) -> NPOutp:
+    x: NPBroadcType,
+    x0: NPBroadcType,
+    y0: NPBroadcType,
+    a: NPBroadcType,
+    sigma: NPBroadcType,
+) -> NPBroadcType:
     gauss = y0 + a * np.exp(-((x - x0) ** 2) / (2 * sigma**2))  # type: ignore
-    return cast(NPOutp, gauss)
+    return cast(NPBroadcType, gauss)
 
 
 def Voigt(
-    x: NPInp,
-    x0: NPInp,
-    y0: NPInp,
-    a: NPInp,
-    sigma: NPInp,
-    gamma: NPInp,
-) -> NPOutp:
+    x: NPBroadcType,
+    x0: NPBroadcType,
+    y0: NPBroadcType,
+    a: NPBroadcType,
+    sigma: NPBroadcType,
+    gamma: NPBroadcType,
+) -> NPBroadcType:
     # sigma = alpha / np.sqrt(2 * np.log(2))
     voigt = y0 + a * np.real(
         wofz((x - x0 + 1j * gamma) / sigma / np.sqrt(2))
     ) / sigma / np.sqrt(2 * np.pi)
-    return cast(NPOutp, voigt)
+    return cast(NPBroadcType, voigt)
 
 
 def get_spectral_sky_data(

--- a/karabo/util/hdf5_util.py
+++ b/karabo/util/hdf5_util.py
@@ -1,9 +1,16 @@
+from typing import Any, Dict, Generator, Tuple, Union
+
 import h5py as h5
 import healpy as hp
 import numpy as np
+from h5py._hl.base import KeysViewHDF5
+from numpy.typing import NDArray
 
 
-def h5_diter(g, prefix=""):
+def h5_diter(
+    g: Dict[str, Union[h5.Dataset, h5.Group]],
+    prefix: str = "",
+) -> Generator[Tuple[str, h5.Dataset], Any, Any]:
     """
     Get the data elements from the hdf5 datasets and groups
     Input: HDF5 file
@@ -17,7 +24,7 @@ def h5_diter(g, prefix=""):
             yield from h5_diter(item, path)
 
 
-def print_hd5_object_and_keys(hdffile):
+def print_hd5_object_and_keys(hdffile: Any) -> Tuple[h5.File, KeysViewHDF5]:
     """
     Read HDF5 file
     Returns: HDF Object, relavent keys
@@ -28,7 +35,7 @@ def print_hd5_object_and_keys(hdffile):
     return f, f.keys()
 
 
-def get_healpix_image(hdffile):
+def get_healpix_image(hdffile: Any) -> Any:
     """
     Get index maps, maps and frequency from HDF5 file
     """
@@ -42,7 +49,7 @@ def get_healpix_image(hdffile):
     return mapp
 
 
-def get_vis_from_hdf5(hdffile):
+def get_vis_from_hdf5(hdffile: Any) -> Any:
     """
     Get index maps, maps and frequency from HDF5 file
     """
@@ -54,7 +61,7 @@ def get_vis_from_hdf5(hdffile):
     return vis
 
 
-def convert_healpix_2_radec(arr):
+def convert_healpix_2_radec(arr: NDArray[Any]) -> Tuple[np.float64, np.float64, int]:
     """
     Convert array from healpix to 2-D array of RADEC
     :param arr:

--- a/karabo/util/hdf5_util.py
+++ b/karabo/util/hdf5_util.py
@@ -61,7 +61,7 @@ def get_vis_from_hdf5(hdffile: Any) -> Any:
     return vis
 
 
-def convert_healpix_2_radec(arr: NDArray[Any]) -> Tuple[np.float64, np.float64, int]:
+def convert_healpix_2_radec(arr: NDArray[Any]) -> Tuple[np.float_, np.float_, int]:
     """
     Convert array from healpix to 2-D array of RADEC
     :param arr:

--- a/karabo/util/math_util.py
+++ b/karabo/util/math_util.py
@@ -73,7 +73,7 @@ def get_poisson_disk_sky(
     flux_min: FloatLike,
     flux_max: FloatLike,
     r: int = 10,
-) -> NDArray[np.float64]:
+) -> NDArray[np.float_]:
     assert flux_max >= flux_min
     x = min_size[0]
     y = min_size[1]
@@ -96,13 +96,13 @@ def get_poisson_disk_sky(
 
 
 #
-def long_lat_to_cartesian(lat: NPFloatLike, lon: NPFloatLike) -> NDArray[np.float64]:
+def long_lat_to_cartesian(lat: NPFloatLike, lon: NPFloatLike) -> NDArray[np.float_]:
     lat_, lon_ = np.deg2rad(lat), np.deg2rad(lon)
     x = R * cos(lat_) * cos(lon_)
     y = R * cos(lat_) * sin(lon_)
     z = R * sin(lat_)
     out = cast(
-        NDArray[np.float64], np.array([x, y, z]) / np.linalg.norm(np.array([x, y, z]))
+        NDArray[np.float_], np.array([x, y, z]) / np.linalg.norm(np.array([x, y, z]))
     )
     return out
 

--- a/karabo/util/math_util.py
+++ b/karabo/util/math_util.py
@@ -1,35 +1,42 @@
 import math
 from math import ceil, cos, floor, pi, sin, sqrt
-from typing import Tuple
+from typing import List, Literal, Tuple, Union, cast
 
 import numpy as np
+from numpy.typing import NDArray
+
+from karabo.util.my_types import FloatLike, NPFloatLike
 
 
-def euclidean_distance(a, b):
-    dx = a[0] - b[0]
-    dy = a[1] - b[1]
-    return sqrt(dx * dx + dy * dy)
-
-
-def poisson_disc_samples(width, height, r, k=5, distance=euclidean_distance):
+def poisson_disc_samples(
+    width: FloatLike,
+    height: FloatLike,
+    r: int,
+    k: int = 5,
+    ord: Union[None, float, Literal["fro", "nuc"]] = None,
+) -> List[Tuple[float, float]]:
     tau = 2 * pi
     cellsize = r / sqrt(2)
     random = np.random.rand
     grid_width = int(ceil(width / cellsize))
     grid_height = int(ceil(height / cellsize))
-    grid = [None] * (grid_width * grid_height)
+    grid = [(np.inf, np.inf)] * (grid_width * grid_height)
 
-    def grid_coords(p):
+    def grid_coords(p: Tuple[float, float]) -> Tuple[int, int]:
         return int(floor(p[0] / cellsize)), int(floor(p[1] / cellsize))
 
-    def fits(p, gx, gy):
+    def fits(
+        p: Tuple[float, float],
+        gx: int,
+        gy: int,
+    ) -> bool:
         yrange = list(range(max(gy - 2, 0), min(gy + 3, grid_height)))
         for x in range(max(gx - 2, 0), min(gx + 3, grid_width)):
             for y in yrange:
                 g = grid[x + y * grid_width]
-                if g is None:
+                if g == (np.inf, np.inf):
                     continue
-                if distance(p, g) <= r:
+                if np.linalg.norm(np.array(p) - np.array(g), ord=ord) <= r:
                     return False
         return True
 
@@ -56,23 +63,24 @@ def poisson_disc_samples(width, height, r, k=5, distance=euclidean_distance):
                 continue
             queue.append(p)
             grid[grid_x + grid_y * grid_width] = p
-    return [p for p in grid if p is not None]
+    grid = [p for p in grid if p != (np.inf, np.inf)]
+    return grid
 
 
 def get_poisson_disk_sky(
-    min_size: Tuple[float, float],
-    max_size: Tuple[float, float],
-    flux_min: float,
-    flux_max: float,
-    r=10,
-):
+    min_size: Tuple[FloatLike, FloatLike],
+    max_size: Tuple[FloatLike, FloatLike],
+    flux_min: FloatLike,
+    flux_max: FloatLike,
+    r: int = 10,
+) -> NDArray[np.float64]:
     assert flux_max >= flux_min
     x = min_size[0]
     y = min_size[1]
     X = max_size[0]
     Y = max_size[1]
-    width = abs(X - x)
-    height = abs(Y - y)
+    width = cast(FloatLike, abs(X - x))
+    height = cast(FloatLike, abs(Y - y))
     center_x = x + (X - x) * 0.5
     center_y = y + (Y - y) * 0.5
     samples = poisson_disc_samples(width, height, r)
@@ -88,12 +96,15 @@ def get_poisson_disk_sky(
 
 
 #
-def long_lat_to_cartesian(lat, lon):
-    lat, lon = np.deg2rad(lat), np.deg2rad(lon)
-    x = R * cos(lat) * cos(lon)
-    y = R * cos(lat) * sin(lon)
-    z = R * sin(lat)
-    return np.array([x, y, z]) / np.linalg.norm(np.array([x, y, z]))
+def long_lat_to_cartesian(lat: NPFloatLike, lon: NPFloatLike) -> NDArray[np.float64]:
+    lat_, lon_ = np.deg2rad(lat), np.deg2rad(lon)
+    x = R * cos(lat_) * cos(lon_)
+    y = R * cos(lat_) * sin(lon_)
+    z = R * sin(lat_)
+    out = cast(
+        NDArray[np.float64], np.array([x, y, z]) / np.linalg.norm(np.array([x, y, z]))
+    )
+    return out
 
 
 #
@@ -107,7 +118,11 @@ def long_lat_to_cartesian(lat, lon):
 R = 6360000  # earth radius
 
 
-def cartesian_to_ll(x, y, z=0):
+def cartesian_to_ll(
+    x: FloatLike,
+    y: FloatLike,
+    z: int = 0,
+) -> Tuple[float, float]:
     # does not use `z`
     r = math.sqrt(x**2 + y**2)
     long = 180 * math.atan2(y, x) / math.pi

--- a/karabo/util/my_types.py
+++ b/karabo/util/my_types.py
@@ -1,17 +1,43 @@
 from typing import Union
 
 import numpy as np
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike
 from typing_extensions import TypeAlias
 
-NPInp: TypeAlias = Union[
+# numpy dtypes
+NPBoolLike = Union[bool, np.bool_]
+NPUIntLike = Union[
+    bool, np.unsignedinteger
+]  # not BoolLike because "-" doesn't support np.bool_
+NPIntLike = Union[
+    bool, int, np.integer
+]  # not BoolLike because "-" doesn't support np.bool_
+NPFloatLike = Union[NPIntLike, float, np.floating]
+NPComplexLike = Union[NPFloatLike, complex, np.complexfloating]
+NPTD64Like = Union[NPIntLike, np.timedelta64]
+NPNumberLike = Union[int, float, complex, np.number, np.bool_]
+NPScalarLike = Union[
     int,
     float,
-    NDArray[np.float64],
-    NDArray[np.int64],
+    complex,
+    str,
+    bytes,
+    np.generic,
+]
+NPBroadcType: TypeAlias = Union[
+    NPFloatLike,
+    ArrayLike,
 ]
 
-NPOutp: TypeAlias = Union[
-    NDArray[np.float64],
-    NDArray[np.int64],
+# similar to `numpy dtypes` but without numpy
+IntLike = Union[bool, int]
+FloatLike = Union[IntLike, float]
+ComplexLike = Union[FloatLike, complex]
+NumberLike = ComplexLike
+ScalarLike = Union[
+    int,
+    float,
+    complex,
+    str,
+    bytes,
 ]

--- a/karabo/util/plotting_util.py
+++ b/karabo/util/plotting_util.py
@@ -1,15 +1,17 @@
+from typing import List
+
 from astropy.wcs import WCS
 
 
-def get_slices(wcs: WCS):
-    slices = []
+def get_slices(wcs: WCS) -> List[str]:
+    slices: List[str] = []
     for i in range(wcs.pixel_n_dim):
         if i == 0:
             slices.append("x")
         elif i == 1:
             slices.append("y")
         else:
-            slices.append(0)
+            slices.append(0)  # type: ignore
     return slices
 
 


### PR DESCRIPTION
Part of #304 

- Introduced some number-like types in my_types.py to handle number-like types and numpy broadcasting to some extend
- The following files are now mypy --strict: hdf5_util.py, math_util.py, sky_model.py, visibility.py
- Moved `simulate_foreground_vis` from visibility.py to interferometer.py to avoid cyclic dependency
- Made deep-copies of all filter-functions of `SkyModel` to be consistent. Before we copied and returned just `filter_by_raidus` but not `filter_by_flux` and `filter_by_frequency`
- Removed `nside` from `SkyModel` constructor because it did nothing. But maybe it was meant to do something, but I couldn't figure that out.
- `SkyModel` `shape` and `num_sources` are now properties instead of updating them each time we change something in`source`.
- Other minor changes in `SkyModel`

The types are for sure not perfect, I also had to use `type: ignore` several times, because fixing that would have required too much effort.

