### PR TITLE
Vt 393 parallelization of oskar fix

### DIFF
--- a/karabo/simulation/observation.py
+++ b/karabo/simulation/observation.py
@@ -232,4 +232,4 @@ class ObservationLong(Observation):
                 f"`number_of_days` must be >=2 but is {self.number_of_days}!"
             )
         if self.length > timedelta(hours=12):
-            raise KaraboError(f"`length` should be max 4 hours but is {self.length}!")
+            raise KaraboError(f"`length` should be max 12 hours but is {self.length}!")

--- a/karabo/simulation/observation.py
+++ b/karabo/simulation/observation.py
@@ -2,8 +2,6 @@ import copy
 from datetime import datetime, timedelta
 from typing import List, Union
 
-import numpy as np
-
 from karabo.error import KaraboError
 from karabo.util._types import IntFloat, OskarSettingsTreeType
 
@@ -165,52 +163,6 @@ class Observation:
             obs["observation"]["frequency_inc_hz"] = cb
             observations.append(obs)
         return observations
-
-    @staticmethod
-    def extract_multiple_observations_from_settings(
-        settings: OskarSettingsTreeType,
-        number_of_observations: int,
-        channel_bandwidth_hz: int,
-    ) -> List[OskarSettingsTreeType]:
-        """
-        Extracts the settings of multiple observations from a settings dictionary.
-        This function returns a list of dictionaries containing the settings
-        of each observation. The start_frequency and number_of_channels
-        need to be updated for each observation.
-        """
-        settings_list: List[OskarSettingsTreeType] = []
-
-        # Extract some settings from the dictionary
-        n_channels = int(settings["observation"]["num_channels"])
-        start_frequency_hz = float(settings["observation"]["start_frequency_hz"])
-        freq_inc_hz = float(settings["observation"]["frequency_inc_hz"])
-
-        # Calculate n_channels per split
-        n_channels_per_split = int(
-            np.ceil(n_channels / number_of_observations)
-        )  # round up
-
-        # Calculate the observed frequency
-        observed_frequency_hz = n_channels * freq_inc_hz
-
-        # Create a list of settings for each observation
-        current_start_frequency_hz = (
-            start_frequency_hz - (observed_frequency_hz / 2) + freq_inc_hz / 2
-        )
-
-        while observed_frequency_hz > 0:
-            current_settings = copy.deepcopy(settings)
-            current_settings["observation"]["start_frequency_hz"] = str(
-                current_start_frequency_hz
-            )
-            current_settings["observation"]["num_channels"] = str(n_channels_per_split)
-            settings_list.append(current_settings)
-            current_start_frequency_hz += (
-                n_channels_per_split * channel_bandwidth_hz + 1
-            )
-            observed_frequency_hz -= n_channels_per_split * channel_bandwidth_hz
-
-        return settings_list
 
     def __strfdelta(
         self,

--- a/karabo/test/test_observation.py
+++ b/karabo/test/test_observation.py
@@ -36,3 +36,79 @@ class TestObservation(unittest.TestCase):
             ol.start_date_and_time == dt,
             "ObservationLong constructor with datetime object broken",
         )
+
+    def test_create_observations_oskar_settings_tree(self):
+        central_frequencies_hz = [200, 250, 370, 300, 301]
+        CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
+        N_CHANNELS = [1, 2, 3, 4, 5]
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, central_frequencies_hz, CHANNEL_BANDWIDTHS, N_CHANNELS
+        )
+        for i, observation in enumerate(observations):
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
+
+            assert start_frequency_hz == central_frequencies_hz[i]
+            assert n_channels == N_CHANNELS[i]
+            assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
+
+        central_frequencies_hz = [200, 300, 400]
+        CHANNEL_BANDWIDTHS = 5
+        N_CHANNELS = 1
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, central_frequencies_hz, CHANNEL_BANDWIDTHS, N_CHANNELS
+        )
+
+        for i, observation in enumerate(observations):
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
+
+            assert start_frequency_hz == central_frequencies_hz[i]
+            assert n_channels == N_CHANNELS
+            assert freq_inc_hz == CHANNEL_BANDWIDTHS
+
+        CENTRAL_FREQ = 200
+        CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
+        N_CHANNELS = [1, 2, 3, 4, 5]
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, CENTRAL_FREQ, CHANNEL_BANDWIDTHS, N_CHANNELS
+        )
+
+        for i, observation in enumerate(observations):
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
+
+            assert start_frequency_hz == CENTRAL_FREQ
+            assert n_channels == N_CHANNELS[i]
+            assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
+
+        CENTRAL_FREQ = [200, 300, 400, 500]
+        CHANNEL_BANDWIDTHS = [1, 2]
+        N_CHANNELS = [1, 2]
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, CENTRAL_FREQ, CHANNEL_BANDWIDTHS, N_CHANNELS
+        )
+
+        for i, observation in enumerate(observations):
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
+
+            assert start_frequency_hz == CENTRAL_FREQ[i]
+            assert n_channels == [1, 2, 1, 2][i]
+            assert freq_inc_hz == [1, 2, 1, 2][i]

--- a/karabo/test/test_simulation.py
+++ b/karabo/test/test_simulation.py
@@ -1,12 +1,11 @@
 import os
 import unittest
-from datetime import datetime, timedelta
 
 import numpy as np
 
 from karabo.imaging.imager import Imager
 from karabo.simulation.interferometer import InterferometerSimulation
-from karabo.simulation.observation import Observation
+from karabo.simulation.observation import Observation, ObservationParallized
 from karabo.simulation.sky_model import SkyModel
 from karabo.simulation.telescope import Telescope
 
@@ -49,94 +48,43 @@ class TestSimulation(unittest.TestCase):
 
         simulation.run_simulation(telescope, sky, observation)
 
-    def test_create_observations_oskar_settings_tree(self):
-        central_frequencies_hz = [200, 250, 370, 300, 301]
-        CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
-        N_CHANNELS = [1, 2, 3, 4, 5]
+    def test_parallelization_by_observation(self):
+        sky = SkyModel.get_GLEAM_Sky([76])
+        phase_center = [250, -80]
+        CENTER_FREQUENCIES_HZ = [100e6, 101e6]
+        CHANNEL_BANDWIDTHS_HZ = [1, 2]
+        N_CHANNELS = [4, 8]
 
-        obs = Observation()
-        settings_tree = obs.get_OSKAR_settings_tree()
-        observations = Observation.create_observations_oskar_from_lists(
-            settings_tree, central_frequencies_hz, CHANNEL_BANDWIDTHS, N_CHANNELS
-        )
-        for i, observation in enumerate(observations):
-            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
-            n_channels = int(observation["observation"]["num_channels"])
-            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
-
-            assert start_frequency_hz == central_frequencies_hz[i]
-            assert n_channels == N_CHANNELS[i]
-            assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
-
-        central_frequencies_hz = [200, 300, 400]
-        CHANNEL_BANDWIDTHS = 5
-        N_CHANNELS = 1
-
-        obs = Observation()
-        settings_tree = obs.get_OSKAR_settings_tree()
-        observations = Observation.create_observations_oskar_from_lists(
-            settings_tree, central_frequencies_hz, CHANNEL_BANDWIDTHS, N_CHANNELS
-        )
-
-        for i, observation in enumerate(observations):
-            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
-            n_channels = int(observation["observation"]["num_channels"])
-            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
-
-            assert start_frequency_hz == central_frequencies_hz[i]
-            assert n_channels == N_CHANNELS
-            assert freq_inc_hz == CHANNEL_BANDWIDTHS
-
-        CENTRAL_FREQ = 200
-        CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
-        N_CHANNELS = [1, 2, 3, 4, 5]
-
-        obs = Observation()
-        settings_tree = obs.get_OSKAR_settings_tree()
-        observations = Observation.create_observations_oskar_from_lists(
-            settings_tree, CENTRAL_FREQ, CHANNEL_BANDWIDTHS, N_CHANNELS
-        )
-
-        for i, observation in enumerate(observations):
-            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
-            n_channels = int(observation["observation"]["num_channels"])
-            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
-
-            assert start_frequency_hz == CENTRAL_FREQ
-            assert n_channels == N_CHANNELS[i]
-            assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
-
-    def test_parallelization_by_channel(self):
-        sky_data = np.array(
-            [
-                [20.0, -30.0, 100, 0, 0, 0, 1.0e9, -0.7, 0.0, 0, 0, 0],
-                [20.0, -30.5, 100, 2, 2, 0, 1.0e9, -0.7, 0.0, 0, 50, 45],
-                [20.5, -30.5, 100, 0, 0, 2, 1.0e9, -0.7, 0.0, 0, 10, -10],
-            ]
-        )
-        sky = SkyModel(sky_data)
-        telescope = Telescope.get_SKA1_MID_Telescope()
+        sky = sky.filter_by_radius(0, 0.55, phase_center[0], phase_center[1])
+        telescope = Telescope.get_ASKAP_Telescope()
 
         simulation = InterferometerSimulation(
             channel_bandwidth_hz=1e6, time_average_sec=1
         )
-        observation = Observation(
-            phase_centre_ra_deg=20.0,
-            start_date_and_time=datetime(2022, 9, 1, 23, 00, 00, 521489),
-            length=timedelta(hours=0, minutes=0, seconds=1, milliseconds=0),
-            phase_centre_dec_deg=-30.5,
-            number_of_time_steps=10,
-            start_frequency_hz=200 * 1e6,
-            frequency_increment_hz=1e6,
-            number_of_channels=1,
+
+        obs_parallized = ObservationParallized(
+            center_frequencies_hz=CENTER_FREQUENCIES_HZ,
+            channel_bandwidths_hz=CHANNEL_BANDWIDTHS_HZ,
+            phase_centre_ra_deg=phase_center[0],
+            phase_centre_dec_deg=phase_center[1],
+            number_of_time_steps=24,
+            n_channels=N_CHANNELS,
         )
 
-        visibility = simulation.run_simulation(telescope, sky, observation)
-        visibility.write_to_file("./result/system_noise/noise_vis.ms")
+        visibilities = simulation.run_simulation(telescope, sky, obs_parallized)
 
-        imager = Imager(
-            visibility, imaging_npixel=4096 * 1, imaging_cellsize=50
-        )  # imaging cellsize is over-written in the Imager based on max uv dist.
-        dirty = imager.get_dirty_image()
-        dirty.write_to_file("result/system_noise/noise_dirty.fits", overwrite=True)
-        dirty.plot(title="Flux Density (Jy)")
+        for i, vis in enumerate(visibilities):
+            imager = Imager(
+                vis, imaging_npixel=2048, imaging_cellsize=3.878509448876288e-05
+            )  # imaging cellsize is over-written in the Imager based on max uv dist.
+            dirty = imager.get_dirty_image()
+            dirty.write_to_file(
+                f"result/parallized_by_obs/dirty_{i}.fits", overwrite=True
+            )
+            assert dirty.header["CRVAL4"] == CENTER_FREQUENCIES_HZ[i]
+            assert dirty.header["NAXIS4"] == N_CHANNELS[i]
+            assert dirty.header["CDELT4"] == CHANNEL_BANDWIDTHS_HZ[i]
+
+
+if __name__ == "__main__":
+    TestSimulation.test_parallelization_by_observation(TestSimulation)

--- a/karabo/test/test_simulation.py
+++ b/karabo/test/test_simulation.py
@@ -50,32 +50,32 @@ class TestSimulation(unittest.TestCase):
         simulation.run_simulation(telescope, sky, observation)
 
     def test_create_observations_oskar_settings_tree(self):
-        CENTRAL_FREQS = [200, 250, 370, 300, 301]
+        central_frequencies_hz = [200, 250, 370, 300, 301]
         CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
         N_CHANNELS = [1, 2, 3, 4, 5]
 
         obs = Observation()
         settings_tree = obs.get_OSKAR_settings_tree()
         observations = Observation.create_observations_oskar_from_lists(
-            settings_tree, CENTRAL_FREQS, CHANNEL_BANDWIDTHS, N_CHANNELS
+            settings_tree, central_frequencies_hz, CHANNEL_BANDWIDTHS, N_CHANNELS
         )
         for i, observation in enumerate(observations):
             start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
             n_channels = int(observation["observation"]["num_channels"])
             freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
 
-            assert start_frequency_hz == CENTRAL_FREQS[i]
+            assert start_frequency_hz == central_frequencies_hz[i]
             assert n_channels == N_CHANNELS[i]
             assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
 
-        CENTRAL_FREQS = [200, 300, 400]
+        central_frequencies_hz = [200, 300, 400]
         CHANNEL_BANDWIDTHS = 5
         N_CHANNELS = 1
 
         obs = Observation()
         settings_tree = obs.get_OSKAR_settings_tree()
         observations = Observation.create_observations_oskar_from_lists(
-            settings_tree, CENTRAL_FREQS, CHANNEL_BANDWIDTHS, N_CHANNELS
+            settings_tree, central_frequencies_hz, CHANNEL_BANDWIDTHS, N_CHANNELS
         )
 
         for i, observation in enumerate(observations):
@@ -83,7 +83,7 @@ class TestSimulation(unittest.TestCase):
             n_channels = int(observation["observation"]["num_channels"])
             freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
 
-            assert start_frequency_hz == CENTRAL_FREQS[i]
+            assert start_frequency_hz == central_frequencies_hz[i]
             assert n_channels == N_CHANNELS
             assert freq_inc_hz == CHANNEL_BANDWIDTHS
 

--- a/karabo/test/test_simulation.py
+++ b/karabo/test/test_simulation.py
@@ -1,8 +1,10 @@
 import os
 import unittest
+from datetime import datetime, timedelta
 
 import numpy as np
 
+from karabo.imaging.imager import Imager
 from karabo.simulation.interferometer import InterferometerSimulation
 from karabo.simulation.observation import Observation
 from karabo.simulation.sky_model import SkyModel
@@ -48,29 +50,93 @@ class TestSimulation(unittest.TestCase):
         simulation.run_simulation(telescope, sky, observation)
 
     def test_create_observations_oskar_settings_tree(self):
-        CHANNEL_BANDWIDTH_HZ = 1e6
-        NUM_SPLITS = 5
-        NUM_CHANNELS = 10
-        observation = Observation(
-            start_frequency_hz=100e6,
-            number_of_channels=NUM_CHANNELS,
+        CENTRAL_FREQS = [200, 250, 370, 300, 301]
+        CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
+        N_CHANNELS = [1, 2, 3, 4, 5]
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, CENTRAL_FREQS, CHANNEL_BANDWIDTHS, N_CHANNELS
         )
-        observations = Observation.extract_multiple_observations_from_settings(
-            observation.get_OSKAR_settings_tree(),
-            NUM_SPLITS,
-            CHANNEL_BANDWIDTH_HZ,
+        for i, observation in enumerate(observations):
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
+
+            assert start_frequency_hz == CENTRAL_FREQS[i]
+            assert n_channels == N_CHANNELS[i]
+            assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
+
+        CENTRAL_FREQS = [200, 300, 400]
+        CHANNEL_BANDWIDTHS = 5
+        N_CHANNELS = 1
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, CENTRAL_FREQS, CHANNEL_BANDWIDTHS, N_CHANNELS
         )
 
         for i, observation in enumerate(observations):
-            observation = observation["observation"]
-            assert (
-                float(observation["start_frequency_hz"])
-                == 100e6 + i * CHANNEL_BANDWIDTH_HZ * NUM_CHANNELS / NUM_SPLITS + i * 1
-            )
-            assert float(observation["num_channels"]) == 2
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
 
-        assert len(observations) == NUM_SPLITS
+            assert start_frequency_hz == CENTRAL_FREQS[i]
+            assert n_channels == N_CHANNELS
+            assert freq_inc_hz == CHANNEL_BANDWIDTHS
+
+        CENTRAL_FREQ = 200
+        CHANNEL_BANDWIDTHS = [1, 2, 3, 4, 5]
+        N_CHANNELS = [1, 2, 3, 4, 5]
+
+        obs = Observation()
+        settings_tree = obs.get_OSKAR_settings_tree()
+        observations = Observation.create_observations_oskar_from_lists(
+            settings_tree, CENTRAL_FREQ, CHANNEL_BANDWIDTHS, N_CHANNELS
+        )
+
+        for i, observation in enumerate(observations):
+            start_frequency_hz = float(observation["observation"]["start_frequency_hz"])
+            n_channels = int(observation["observation"]["num_channels"])
+            freq_inc_hz = float(observation["observation"]["frequency_inc_hz"])
+
+            assert start_frequency_hz == CENTRAL_FREQ
+            assert n_channels == N_CHANNELS[i]
+            assert freq_inc_hz == CHANNEL_BANDWIDTHS[i]
 
     def test_parallelization_by_channel(self):
-        # TODO: Do this test
-        pass
+        sky_data = np.array(
+            [
+                [20.0, -30.0, 100, 0, 0, 0, 1.0e9, -0.7, 0.0, 0, 0, 0],
+                [20.0, -30.5, 100, 2, 2, 0, 1.0e9, -0.7, 0.0, 0, 50, 45],
+                [20.5, -30.5, 100, 0, 0, 2, 1.0e9, -0.7, 0.0, 0, 10, -10],
+            ]
+        )
+        sky = SkyModel(sky_data)
+        telescope = Telescope.get_SKA1_MID_Telescope()
+
+        simulation = InterferometerSimulation(
+            channel_bandwidth_hz=1e6, time_average_sec=1
+        )
+        observation = Observation(
+            phase_centre_ra_deg=20.0,
+            start_date_and_time=datetime(2022, 9, 1, 23, 00, 00, 521489),
+            length=timedelta(hours=0, minutes=0, seconds=1, milliseconds=0),
+            phase_centre_dec_deg=-30.5,
+            number_of_time_steps=10,
+            start_frequency_hz=200 * 1e6,
+            frequency_increment_hz=1e6,
+            number_of_channels=1,
+        )
+
+        visibility = simulation.run_simulation(telescope, sky, observation)
+        visibility.write_to_file("./result/system_noise/noise_vis.ms")
+
+        imager = Imager(
+            visibility, imaging_npixel=4096 * 1, imaging_cellsize=50
+        )  # imaging cellsize is over-written in the Imager based on max uv dist.
+        dirty = imager.get_dirty_image()
+        dirty.write_to_file("result/system_noise/noise_dirty.fits", overwrite=True)
+        dirty.plot(title="Flux Density (Jy)")

--- a/karabo/warning.py
+++ b/karabo/warning.py
@@ -2,3 +2,9 @@ class KaraboWarning(Warning):
     """
     Base Warning thrown by the Karabo Pipeline
     """
+
+
+class InterferometerSimulationWarning(KaraboWarning):
+    """
+    Warning thrown by the Interferometer Simulation
+    """


### PR DESCRIPTION
- Implements/fixes parallelization by observation in Oskar
- Adds some tests for it.
- Removes some code and if/else statements in run_simulation and rather processes them in a different spot, if needed.
- Removes parallelization by sky-chunk because currently no method to combine the visibilities exists, which is tested for correctness.