### PR TITLE
added CaptureSpam to KaraboResource

### DIFF
--- a/karabo/karabo_resource.py
+++ b/karabo/karabo_resource.py
@@ -98,11 +98,17 @@ class HiddenPrints:
 class CaptureSpam:
     """Captures spam of `sys.stdout` or `sys.stderr`.
 
-    Captures spam-messages of an external library.
+    Captures exact-match spam-messages of an external library.
     It checks each new line (not an entire print-message with
      multiple multiple newlines), if it has already been printed once.
     Don't use CaptureSpam if the external library function
      provides a way to suppress their output.
+
+    Example usage:
+        ```
+        with CaptureSpam():
+            library_spam_fun()
+        ```
     """
 
     def __init__(self, stream: TextIO = sys.stdout):


### PR DESCRIPTION
Added CaptureSpam to karabo_resource.py to be able to capture third-party library spam-messages.

Should be good enough. I tested it with all print-options (not logging). The only drawback is, that it can only check for each new-line if it has already been printed. So if e.g. a third-party library wraps their output in something like "--------------------\n" multiple times, it gets captured after the first time. It's also not able to capture with regex, just exact-match. But for the second case, CaptureSpam could be extended to support capturing by regex (I think).