### PR TITLE
fixed OSKAR library not found in Dockerfile

### DIFF
--- a/docker/user/Dockerfile
+++ b/docker/user/Dockerfile
@@ -1,33 +1,24 @@
 # Create build container to not have copied filed in real container afterwards
-FROM --platform=amd64 continuumio/miniconda3:4.12.0 as build
+FROM nvidia/cuda:11.7.1-cudnn8-devel-ubuntu22.04 as build
 ARG KARABO_TAG
 RUN apt-get update && apt-get install -y git
 RUN git clone --branch ${KARABO_TAG} --depth=1 https://github.com/i4Ds/Karabo-Pipeline.git
 
-FROM --platform=amd64 continuumio/miniconda3:4.12.0
+FROM nvidia/cuda:11.7.1-cudnn8-devel-ubuntu22.04
 ARG KARABO_TAG
+RUN apt-get update && apt-get install -y libarchive13 wget curl nano
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda
+ENV PATH=/opt/conda/bin:$PATH
+RUN conda init
 SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y curl libarchive13 && apt-get autoclean && rm -rf /var/lib/apt/lists/*
 RUN conda update -y conda && \
-    conda clean --all --yes && \
     conda install mamba -y -c conda-forge
-RUN mamba install -y -c i4ds -c conda-forge -c nvidia/label/cuda-11.7.0 karabo-pipeline="${KARABO_TAG:1}"
-RUN pip install jupyterlab ipykernel
-RUN python -m ipykernel install --user --name=karabo
-RUN mkdir /workspace
+RUN mamba install -y -c i4ds -c conda-forge -c "nvidia/label/cuda-11.7.1" karabo-pipeline="${KARABO_TAG:1}"
+RUN pip install jupyterlab ipykernel pytest && \
+    python -m ipykernel install --user --name=karabo && \
+    mkdir /workspace
 WORKDIR /workspace
 COPY --from=build Karabo-Pipeline/ repo/
-RUN cp -r repo/karabo/examples /workspace/examples/
-
-# test karabo
-# repo/ ensures that karabo is from site-packages and not from local
-# tmp because tests produce pemanent files
-# comment out ONLY the next layer to disable testing
-# RUN mkdir tmp && \
-#     cp -r repo/ tmp/repo && \
-#     cd tmp && \
-#     if [[ -f "repo/requirements.txt" ]] ; then pip install -r repo/requirements.txt ; else pip install pytest ; fi && \
-#     python -c "from karabo.util.testing import run_tests; run_tests()" && \
-#     cd .. && \
-#     rm -rf tmp/
-RUN rm -rf repo/
+RUN cp -r repo/karabo/examples /workspace/examples/ && \
+    rm -rf repo/


### PR DESCRIPTION
There was an issue using all our [docker-images](https://github.com/i4ds/Karabo-Pipeline/pkgs/container/karabo-pipeline) up until version `0.18.0`. `run_simulation` failed, where OSKAR python bindings claimed, that OSKAR library was not found (see image blow). This is essentially not true. They just failed an import of a sub-dependency. The issue was, that they captured their import error in `settings_tree.py`:

```python
try:
    from . import _settings_lib
    from . import _apps_lib
except ImportError:
    _settings_lib = None
    _apps_lib = None
```
There they try to import `_settings_lib.cpython-39-x86_64-linux-gnu.so` and `_apps_lib.cpython-39-x86_64-linux-gnu.so` which are their own .so files available in the oskar package location. The main issue is, that there they point to the exact cuda-runtime file `libcudart.so.11.0` (exact match for whatever reason) which comes with `cuda-toolkit 11.*` and didn't find it. This means, that the system must provide `cuda-toolkit 11.*` or OSKAR will fail when creating a settings-tree.

`cuda-toolkit 11.*`  was not available our docker-environment. I thought it must come as a dependency since we already have some cuda-toolkit dependencies in karabo like `cuda-cudart` or `libcufft`. However, it was ont available. I also tried to install the cuda toolkit manually using `conda install -c "nvidia/label/cuda-11.7.0" cuda-toolkit`. But it didn't work either. I tried to install the cuda-toolkit from the official [developer.nvidia](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_local). There I got an error, that the glibc version `libc6 2.31-13+deb11u3` version of the previous used base-image [continuumio/miniconda3](https://hub.docker.com/r/continuumio/miniconda3) was too low, because to install the nvidia-toolkit 11.*, at least `libc6 >=2.34` is required. Even their latest base image didn't reach the glibc requirement. I assume that this is the issue, why the cuda-toolkit wasn't successfully installed. But not sure though, I don't have experience for this kind of stuff.

So in the end, what worked was taking the base-image `nvidia/cuda:11.7.1-cudnn8-devel-ubuntu22.04` which had the nvidia-toolkit installed and the required file was there. Also the glibc requirement (`libc6 = 2.35`) was met.  The code shown in the image-below succeeded in the new build. So I think it is fine to include it as it is to the main-branch (even though the images are still not fully tested).

![image](https://github.com/i4Ds/Karabo-Pipeline/assets/32157249/a45e1c50-ba1d-4a16-8baf-d20b124c8f2f)
