### PR TITLE
Improve line emission end-to-end test with golden files

### DIFF
--- a/karabo/simulation/line_emission.py
+++ b/karabo/simulation/line_emission.py
@@ -25,7 +25,7 @@ from karabo.simulation.observation import Observation
 from karabo.simulation.sky_model import SkyModel
 from karabo.simulation.telescope import Telescope
 from karabo.simulation.visibility import Visibility
-from karabo.util._types import IntFloat, NPFloatLikeStrict
+from karabo.util._types import DirPathType, FilePathType, IntFloat, NPFloatLikeStrict
 from karabo.util.dask import DaskHandler
 
 
@@ -170,7 +170,7 @@ def oskar_imager(
 def plot_scatter_recon(
     sky: SkyModel,
     recon_image: NDArray[np.float_],
-    outfile: Union[Path, str],
+    outfile: FilePathType,
     header: fits.header.Header,
     vmin: IntFloat = 0,
     vmax: Optional[IntFloat] = None,
@@ -306,7 +306,7 @@ def freq_channels(
 
 
 def karabo_reconstruction(
-    outfile: Union[Path, str],
+    outfile: FilePathType,
     mosaic_pntg_file: Optional[str] = None,
     sky: Optional[SkyModel] = None,
     ra_deg: IntFloat = 20,
@@ -434,7 +434,7 @@ def karabo_reconstruction(
 
 
 def run_one_channel_simulation(
-    path: Union[Path, str],
+    path: FilePathType,
     sky: SkyModel,
     bin_idx: int,
     z_min: np.float_,
@@ -516,7 +516,7 @@ def run_one_channel_simulation(
 
 
 def line_emission_pointing(
-    outpath_base: Union[Path, str],
+    outpath_base: DirPathType,
     sky: SkyModel,
     outfile_stem: str = "test_line_emission",
     ra_deg: IntFloat = 20,
@@ -689,7 +689,7 @@ def gaussian_beam(
     img_size: int = 2048,
     cut: IntFloat = 1.2,
     fwhm: NPFloatLikeStrict = 1.0,
-    outfile: Union[Path, str] = "beam",
+    outfile: FilePathType = "beam",
 ) -> Tuple[NDArray[np.float_], fits.header.Header]:
     """
     Creates a Gaussian beam at RA, DEC.
@@ -725,7 +725,7 @@ def gaussian_beam(
 
 
 def simple_gaussian_beam_correction(
-    path_outfile: Union[Path, str],
+    path_outfile: DirPathType,
     dirty_image: NDArray[np.float_],
     gaussian_fwhm: NPFloatLikeStrict,
     ra_deg: IntFloat = 20,

--- a/karabo/simulation/line_emission.py
+++ b/karabo/simulation/line_emission.py
@@ -125,7 +125,7 @@ def rascil_imager(
         imaging_dopsf=True,
     )
     dirty = imager.get_dirty_image()
-    dirty.write_to_file(outfile + ".fits", overwrite=True)
+    dirty.write_to_file(f"{outfile}.fits", overwrite=True)
     dirty_image = cast(NDArray[np.float_], dirty.data[0][0])
 
     return dirty_image
@@ -152,7 +152,7 @@ def oskar_imager(
     # Here plenty of options are available that could be found in the documentation.
     # uv_filter_max can be used to change the baseline length threshold
     imager.set(
-        input_file=outfile + ".vis",
+        input_file=f"{outfile}.vis",
         output_root=outfile,
         fov_deg=cut,
         image_size=img_size,
@@ -370,7 +370,7 @@ def karabo_reconstruction(
     if verbose:
         print("Sky Simulation...")
     simulation = InterferometerSimulation(
-        vis_path=str(outfile) + ".vis",
+        vis_path=f"{outfile}.vis",
         channel_bandwidth_hz=1.0e7,
         time_average_sec=8,
         ignore_w_components=True,
@@ -419,7 +419,7 @@ def karabo_reconstruction(
                 "Creation of a pdf with scatter plot and reconstructed image to ",
                 str(outfile),
             )
-        plot_scatter_recon(sky, dirty_image, str(outfile) + ".pdf", header)
+        plot_scatter_recon(sky, dirty_image, f"{outfile}.pdf", header)
 
     if mosaic_pntg_file is not None:
         if verbose:
@@ -428,7 +428,7 @@ def karabo_reconstruction(
                 "coaddition.",
                 mosaic_pntg_file,
             )
-        fits.writeto(mosaic_pntg_file + ".fits", dirty_image, header, overwrite=True)
+        fits.writeto(f"{mosaic_pntg_file}.fits", dirty_image, header, overwrite=True)
 
     return dirty_image, header
 
@@ -611,7 +611,7 @@ def line_emission_pointing(
     for bin_idx in range(num_bins):
         if verbose:
             print(
-                "Channel " + str(bin_idx) + " is being processed...\n"
+                f"Channel {bin_idx} is being processed...\n"
                 "Extracting the corresponding frequency slice from the sky model..."
             )
         delayed_ = delayed(run_one_channel_simulation)(
@@ -649,7 +649,7 @@ def line_emission_pointing(
     print("Save summed dirty images as fits file")
     dirty_img = fits.PrimaryHDU(dirty_image, header=header)
     dirty_img.writeto(
-        outpath_base / (outfile_stem + ".fits"),
+        outpath_base / (f"{outfile_stem}.fits"),
         overwrite=True,
     )
 
@@ -658,7 +658,7 @@ def line_emission_pointing(
     z_channel_mid = redshift_channel + z_bin / 2
 
     f = h5py.File(
-        outpath_base / (outfile_stem + ".h5"),
+        outpath_base / (f"{outfile_stem}.h5"),
         "w",
     )
     dataset_dirty = f.create_dataset("Dirty Images", data=dirty_images)

--- a/karabo/test/test_line_emission.py
+++ b/karabo/test/test_line_emission.py
@@ -1,7 +1,12 @@
-import os
 import tempfile
+from pathlib import Path
 
-from karabo.data.external_data import DilutedBATTYESurveyDownloadObject
+import h5py
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from karabo.data.external_data import DilutedBATTYESurveyDownloadObject, DownloadObject
 from karabo.simulation.line_emission import (
     gaussian_fwhm_meerkat,
     line_emission_pointing,
@@ -12,31 +17,194 @@ from karabo.simulation.sky_model import SkyModel
 from karabo.util.dask import DaskHandler
 
 
-def test_line_emission_run():
+# DownloadObject instances used to download different golden files:
+# - FITS file before beam correction
+# - H5 file with channels stored separately, before beam correction
+# - FITS file after beam correction
+@pytest.fixture
+def uncorrected_fits_filename():
+    return "test_line_emission.fits"
+
+
+@pytest.fixture
+def uncorrected_h5_filename():
+    return "test_line_emission.h5"
+
+
+@pytest.fixture
+def corrected_fits_filename():
+    return "test_line_emission_GaussianBeam_Corrected.fits"
+
+
+@pytest.fixture
+def uncorrected_fits_downloader(uncorrected_fits_filename):
+    return DownloadObject(
+        uncorrected_fits_filename,
+        "https://object.cscs.ch/v1/AUTH_1e1ed97536cf4e8f9e214c7ca2700d62"
+        + f"/karabo_public/{uncorrected_fits_filename}",
+    )
+
+
+@pytest.fixture
+def uncorrected_h5_downloader(uncorrected_h5_filename):
+    return DownloadObject(
+        uncorrected_h5_filename,
+        "https://object.cscs.ch/v1/AUTH_1e1ed97536cf4e8f9e214c7ca2700d62"
+        + f"/karabo_public/{uncorrected_h5_filename}",
+    )
+
+
+@pytest.fixture
+def corrected_fits_downloader(corrected_fits_filename):
+    return DownloadObject(
+        corrected_fits_filename,
+        "https://object.cscs.ch/v1/AUTH_1e1ed97536cf4e8f9e214c7ca2700d62"
+        + f"/karabo_public/{corrected_fits_filename}",
+    )
+
+
+def test_line_emission_run(
+    uncorrected_fits_filename,
+    uncorrected_h5_filename,
+    corrected_fits_filename,
+    uncorrected_fits_downloader,
+    uncorrected_h5_downloader,
+    corrected_fits_downloader,
+):
     DaskHandler.n_threads_per_worker = 1
 
-    # Read in the sky
+    # Download golden files for comparison
+    golden_uncorrected_fits_path = uncorrected_fits_downloader.get()
+    golden_uncorrected_h5_path = uncorrected_h5_downloader.get()
+    golden_corrected_fits_path = corrected_fits_downloader.get()
+
+    # Load sky model data
     survey = DilutedBATTYESurveyDownloadObject()
     catalog_path = survey.get()
+
+    # Directory containing output files for validation
     with tempfile.TemporaryDirectory() as tmpdir:
-        outpath = os.path.join(tmpdir, "test_line_emission")
+        tmpdir_path = Path(tmpdir)
+        uncorrected_fits_path = tmpdir_path / uncorrected_fits_filename
+        uncorrected_h5_path = tmpdir_path / uncorrected_h5_filename
+        corrected_fits_path = tmpdir_path / corrected_fits_filename
+
+        outpath = str(tmpdir_path / "test_line_emission")
+
+        # Set sky position for pointing
         ra = 20
         dec = -30
-        cut = 1.0
+        cut = 1.0  # degrees
+
         sky_pointing = SkyModel.sky_from_h5_with_redshift_filtered(
             path=catalog_path, ra_deg=ra, dec_deg=dec, outer_rad=3
         )
+
         # Simulation of line emission observation
         dirty_im, _, header_dirty, freq_mid_dirty = line_emission_pointing(
             path_outfile=outpath, sky=sky_pointing, cut=cut, img_size=1024
         )
+
+        # Validate uncorrected H5 file,
+        # which results from the line emission simulation
+        golden_uncorrected_h5_file = h5py.File(golden_uncorrected_h5_path, "r")
+        uncorrected_h5_file = h5py.File(uncorrected_h5_path, "r")
+
+        # Check each H5 dataset individually
+        assert (
+            golden_uncorrected_h5_file["Dirty Images"].shape
+            == uncorrected_h5_file["Dirty Images"].shape
+        )
+        assert (
+            golden_uncorrected_h5_file["Dirty Images"].attrs["Units"]
+            == uncorrected_h5_file["Dirty Images"].attrs["Units"]
+        )
+
+        for golden_dirty_image, dirty_image in zip(
+            golden_uncorrected_h5_file["Dirty Images"],
+            uncorrected_h5_file["Dirty Images"],
+        ):
+            assert np.allclose(
+                golden_dirty_image,
+                dirty_image,
+                equal_nan=True,
+            )
+
+        assert (
+            golden_uncorrected_h5_file["Observed Redshift Bin Size"][()]
+            == uncorrected_h5_file["Observed Redshift Bin Size"][()]
+        )
+
+        assert np.array_equal(
+            golden_uncorrected_h5_file["Observed Redshift Channel Center"],
+            uncorrected_h5_file["Observed Redshift Channel Center"],
+        )
+
+        # Verify uncorrected FITS file,
+        # which results from the line emission simulation
+        uncorrected_fits_data, uncorrected_fits_header = fits.getdata(
+            uncorrected_fits_path, header=True
+        )
+        golden_uncorrected_fits_data, golden_uncorrected_fits_header = fits.getdata(
+            golden_uncorrected_fits_path, header=True
+        )
+
+        # Check FITS data is close to goldenfile
+        assert np.allclose(
+            golden_uncorrected_fits_data,
+            uncorrected_fits_data,
+            equal_nan=True,
+        )
+
+        # Check that headers contain the same keys
+        assert set(golden_uncorrected_fits_header.keys()) == set(
+            uncorrected_fits_header.keys()
+        )
+
+        # Check that header fields have the same values
+        for k in golden_uncorrected_fits_header.keys():
+            assert golden_uncorrected_fits_header[k] == uncorrected_fits_header[k]
+
+        # Generate scatter plot, to validate that plotting can run
         plot_scatter_recon(sky_pointing, dirty_im, outpath, header_dirty, cut=cut)
 
-        # Primary beam correction
+        # Generate Gaussian primary beam for correction,
+        # and apply correction to dirty images
         gauss_fwhm = gaussian_fwhm_meerkat(freq_mid_dirty)
+
         beam_corrected, _ = simple_gaussian_beam_correction(
-            outpath, dirty_im, gauss_fwhm, cut=cut, img_size=1024
+            outpath,
+            dirty_im,
+            gauss_fwhm,
+            cut=cut,
+            img_size=1024,  # Small image size for testing purposes
         )
+
+        # Validate output FITS file after beam correction
+        corrected_fits_data, corrected_fits_header = fits.getdata(
+            corrected_fits_path, header=True
+        )
+        golden_corrected_fits_data, golden_corrected_fits_header = fits.getdata(
+            golden_corrected_fits_path, header=True
+        )
+
+        # Check FITS data is close to goldenfile
+        assert np.allclose(
+            golden_corrected_fits_data,
+            corrected_fits_data,
+            equal_nan=True,
+        )
+
+        # Check that headers contain the same keys
+        assert set(golden_corrected_fits_header.keys()) == set(
+            corrected_fits_header.keys()
+        )
+
+        # Check that header fields have the same values
+        for k in golden_corrected_fits_header.keys():
+            assert golden_corrected_fits_header[k] == corrected_fits_header[k]
+
+        # Generate plot using the corrected FITS data
         plot_scatter_recon(
             sky_pointing,
             beam_corrected,
@@ -44,4 +212,5 @@ def test_line_emission_run():
             header_dirty,
             cut=cut,
         )
+
         print("Finished")

--- a/karabo/test/test_line_emission.py
+++ b/karabo/test/test_line_emission.py
@@ -71,6 +71,24 @@ def test_line_emission_run(
     uncorrected_h5_downloader,
     corrected_fits_downloader,
 ):
+    """Executes the line emission pipeline and validates the output files.
+
+    The line emission pipeline consists of the following steps:
+       Load sky model with input sources.
+       Prepare sky pointing, which keeps only sources within
+       a given field of view.
+       Simulate the line emission observation.
+       Prepare a Gaussian beam, and apply beam correction to pointing result.
+
+    Args:
+      uncorrected_fits_filename:
+        Name of FITS file containing added images before beam correction.
+      uncorrected_h5_filename:
+        Name of HDF5 file containing individual images from each channel,
+        before beam correction.
+      corrected_fits_filename:
+        Name of FITS file containing added images after beam correction.
+    """
     DaskHandler.n_threads_per_worker = 1
 
     # Download golden files for comparison

--- a/karabo/test/test_line_emission.py
+++ b/karabo/test/test_line_emission.py
@@ -102,12 +102,10 @@ def test_line_emission_run(
 
     # Directory containing output files for validation
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir_path = Path(tmpdir)
-        uncorrected_fits_path = tmpdir_path / uncorrected_fits_filename
-        uncorrected_h5_path = tmpdir_path / uncorrected_h5_filename
-        corrected_fits_path = tmpdir_path / corrected_fits_filename
-
-        outpath = str(tmpdir_path / "test_line_emission")
+        outpath = Path(tmpdir)
+        uncorrected_fits_path = outpath / uncorrected_fits_filename
+        uncorrected_h5_path = outpath / uncorrected_h5_filename
+        corrected_fits_path = outpath / corrected_fits_filename
 
         # Set sky position for pointing
         ra = 20
@@ -120,7 +118,7 @@ def test_line_emission_run(
 
         # Simulation of line emission observation
         dirty_im, _, header_dirty, freq_mid_dirty = line_emission_pointing(
-            path_outfile=outpath, sky=sky_pointing, cut=cut, img_size=1024
+            outpath_base=outpath, sky=sky_pointing, cut=cut, img_size=1024
         )
 
         # Validate uncorrected H5 file,
@@ -184,7 +182,13 @@ def test_line_emission_run(
             assert golden_uncorrected_fits_header[k] == uncorrected_fits_header[k]
 
         # Generate scatter plot, to validate that plotting can run
-        plot_scatter_recon(sky_pointing, dirty_im, outpath, header_dirty, cut=cut)
+        plot_scatter_recon(
+            sky_pointing,
+            dirty_im,
+            outpath / "test_line_emission.pdf",
+            header_dirty,
+            cut=cut,
+        )
 
         # Generate Gaussian primary beam for correction,
         # and apply correction to dirty images
@@ -226,7 +230,7 @@ def test_line_emission_run(
         plot_scatter_recon(
             sky_pointing,
             beam_corrected,
-            outpath + "_GaussianBeam_Corrected",
+            outpath / "test_line_emission_GaussianBeam_Corrected.pdf",
             header_dirty,
             cut=cut,
         )

--- a/karabo/util/_types.py
+++ b/karabo/util/_types.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Union
 
 import numpy as np
@@ -65,3 +66,10 @@ IntFloatList: TypeAlias = Union[List[int], List[float]]
 PrecisionType: TypeAlias = Literal["single", "double"]
 
 OskarSettingsTreeType: TypeAlias = Dict[str, Dict[str, Any]]
+
+# File handling types
+
+# Used for directory paths, to which one can append a file name
+DirPathType: TypeAlias = Union[Path, str]
+# Used for file paths
+FilePathType: TypeAlias = Union[Path, str]


### PR DESCRIPTION
The test function now has `assert` statements to check the intermediate files from the line emission pointing, as well as the final results from the beam correction.

The code was checked using the precommit hooks in the repo, but let me know if there are any additional formatting checks that should happen.