### PR TITLE
Improve PINOCCHIO test and remove unnecessary feature

### DIFF
--- a/karabo/simulation/pinocchio.py
+++ b/karabo/simulation/pinocchio.py
@@ -725,7 +725,7 @@ class Pinocchio:
         and translated into RA DEC
 
         :param path: path to the past light cone file, if there is no file,
-        use the a pinocchio run to create such a file.
+        use a pinocchio run to create such a file.
         :type path: str
         :param near: starting distance from the (0,0,0) point in [Mpc/h], defaults to 0
         :type near: float, optional

--- a/karabo/simulation/pinocchio.py
+++ b/karabo/simulation/pinocchio.py
@@ -70,7 +70,7 @@ class Pinocchio:
         Load default file paths for config files, load default config files
 
         Args:
-            working_dir: working directory of Phinocchio
+            working_dir: working directory of Pinocchio
         """
         if working_dir is not None:
             working_dir = os.path.abspath(working_dir)
@@ -712,17 +712,24 @@ class Pinocchio:
         path: str, near: IntFloat = 0, far: IntFloat = 100
     ) -> SkyModel:
         """
+        NOTE: the only meaningful fields on this SkyModel will be RA and Dec.
+        PINOCCHIO outputs Dark Matter halos, not HI sources.
+        Therefore, use this as a convenience function to obtain the halo
+        positions in the projected sky, but not as an input to
+        the HI analysis pipeline in Karabo.
+
         Create a sky model from the pinocchio simulation cone. All halos from the near
         to far plane (euclid distance) will be translated into the
         RA (right ascension - [0,360] in deg)
         and DEC (declination - [0, 90] in deg) format.
+
 
         example in 1D - this function will do the same on pinocchios 3D cone:
 
         |               10              60          |
         (0,0,0) --------near------------far--------->
 
-        and translated into RA DEC
+        and translated into RA and DEC.
 
         :param path: path to the past light cone file, if there is no file,
         use a pinocchio run to create such a file.
@@ -764,10 +771,10 @@ class Pinocchio:
 
             skyModArr[i, Pinocchio.PIN_RIGHT_ASCENSION_IDX] = ra
             skyModArr[i, Pinocchio.PIN_DECLINATION_IDX] = dec
-            skyModArr[i, Pinocchio.PIN_I_FLUS_IDX] = 1
-            skyModArr[i, Pinocchio.PIN_Q_FLUS_IDX] = 0
-            skyModArr[i, Pinocchio.PIN_U_FLUS_IDX] = 0
-            skyModArr[i, Pinocchio.PIN_V_FLUS_IDX] = 0
-            skyModArr[i, Pinocchio.PIN_REF_F_IDX] = 1.0e8
+            skyModArr[i, Pinocchio.PIN_I_FLUS_IDX] = None
+            skyModArr[i, Pinocchio.PIN_Q_FLUS_IDX] = None
+            skyModArr[i, Pinocchio.PIN_U_FLUS_IDX] = None
+            skyModArr[i, Pinocchio.PIN_V_FLUS_IDX] = None
+            skyModArr[i, Pinocchio.PIN_REF_F_IDX] = None
 
         return SkyModel(skyModArr)

--- a/karabo/simulation/pinocchio.py
+++ b/karabo/simulation/pinocchio.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from karabo.error import KaraboPinocchioError
-from karabo.simulation.sky_model import SkyModel
 from karabo.util._types import IntFloat
 from karabo.util.file_handle import FileHandle
 
@@ -690,91 +689,3 @@ class Pinocchio:
             plt.savefig("plc.png")
         plt.show(block=False)
         plt.pause(1)
-
-    def getSkyModel(self, near: IntFloat = 0, far: IntFloat = 100) -> SkyModel:
-        """
-        This method should be used on the pinocchio object after run() was called.
-        It is a wrapper for the getSkyModelFromFiles() static method with the correct
-        internal path.
-
-        :param near: near distance, everything below gets clipped, defaults to 0
-        :type near: float, optional
-        :param far: far distance, everything above gets clipped, defaults to 100
-        :type far: float, optional
-        :return: SkyModel with the point sources in radial distance from near to far
-        :rtype: SkyModel
-        """
-        assert self.didRun, "can not get sky model if run() was never called"
-        return Pinocchio.getSkyModelFromFiles(self.outLightConePath, near, far)
-
-    @staticmethod
-    def getSkyModelFromFiles(
-        path: str, near: IntFloat = 0, far: IntFloat = 100
-    ) -> SkyModel:
-        """
-        NOTE: the only meaningful fields on this SkyModel will be RA and Dec.
-        PINOCCHIO outputs Dark Matter halos, not HI sources.
-        Therefore, use this as a convenience function to obtain the halo
-        positions in the projected sky, but not as an input to
-        the HI analysis pipeline in Karabo.
-
-        Create a sky model from the pinocchio simulation cone. All halos from the near
-        to far plane (euclid distance) will be translated into the
-        RA (right ascension - [0,360] in deg)
-        and DEC (declination - [0, 90] in deg) format.
-
-
-        example in 1D - this function will do the same on pinocchios 3D cone:
-
-        |               10              60          |
-        (0,0,0) --------near------------far--------->
-
-        and translated into RA and DEC.
-
-        :param path: path to the past light cone file, if there is no file,
-        use a pinocchio run to create such a file.
-        :type path: str
-        :param near: starting distance from the (0,0,0) point in [Mpc/h], defaults to 0
-        :type near: float, optional
-        :param far: ending distance from the (0,0,0) point in [Mpc/h], default to 100
-        :type far: float, optional
-        :return: SkyModel with the point sources in radial distance from near to far
-        :rtype: SkyModel
-        """
-
-        assert near < far, "near is further or equal to far"
-
-        # load pinocchio data
-        (x, y, z) = np.loadtxt(path, unpack=True, usecols=(2, 3, 4))
-
-        assert x.shape == y.shape == z.shape, "x, y, z do not have the same dimensions"
-
-        length: int = len(x)
-        skyModArr = np.empty((length, 7))
-
-        i: int
-        for i in range(length):
-            xPin = x[i]
-            yPin = y[i]
-            zPin = z[i]
-
-            radDist = np.sqrt(xPin**2 + yPin**2 + zPin**2)  # radial distance
-
-            # skip if not between near and far "plane"
-            if radDist < near and radDist > far:
-                continue
-
-            # calculate RA DEC
-            theta = np.arccos(zPin / radDist)  # theta
-            ra = np.arctan2(yPin, xPin) * Pinocchio.RAD_TO_DEG  # RA
-            dec = (np.pi / 2.0 - theta) * Pinocchio.RAD_TO_DEG  # DEC
-
-            skyModArr[i, Pinocchio.PIN_RIGHT_ASCENSION_IDX] = ra
-            skyModArr[i, Pinocchio.PIN_DECLINATION_IDX] = dec
-            skyModArr[i, Pinocchio.PIN_I_FLUS_IDX] = None
-            skyModArr[i, Pinocchio.PIN_Q_FLUS_IDX] = None
-            skyModArr[i, Pinocchio.PIN_U_FLUS_IDX] = None
-            skyModArr[i, Pinocchio.PIN_V_FLUS_IDX] = None
-            skyModArr[i, Pinocchio.PIN_REF_F_IDX] = None
-
-        return SkyModel(skyModArr)

--- a/karabo/test/pinocchio_params.txt
+++ b/karabo/test/pinocchio_params.txt
@@ -1,0 +1,59 @@
+# This is an example parameter file for the Pinocchio 5.0 code
+
+# runProperties
+RunFlag                test      % name of the run
+OutputList             outputs      % name of file with required output redshifts
+BoxSize                500.0        % physical size of the box in Mpc
+BoxInH100                           % specify that the box is in Mpc/h
+GridSize               200          % number of grid points per side
+RandomSeed             486604       % random seed for initial conditions
+
+# cosmology
+Omega0                 0.31         % Omega_0 (total matter)
+OmegaLambda            0.69         % Omega_Lambda
+OmegaBaryon            0.048        % Omega_b (baryonic matter)
+Hubble100              0.67         % little h
+Sigma8                 0.8          % sigma8; if 0, it is computed from the provided P(k)
+PrimordialIndex        0.96         % n_s
+DEw0                   -1.0         % w0 of parametric dark energy equation of state
+DEwa                   0.0          % wa of parametric dark energy equation of state
+TabulatedEoSfile       no           % equation of state of dark energy tabulated in a file
+FileWithInputSpectrum  no           % P(k) tabulated in a file
+                                    % "no" means that the fit of Eisenstein & Hu is used
+
+# n-GenIC
+InputSpectrum_UnitLength_in_cm 0    % units of tabulated P(k), or 0 if it is in h/Mpc
+WDM_PartMass_in_kev    0.0          % WDM cut following Bode, Ostriker & Turok (2001)
+
+# memorySettings
+BoundaryLayerFactor    3.0          % width of the boundary layer for fragmentation
+MaxMem                 3600         % max available memory to an MPI task in Mbyte
+MaxMemPerParticle      150          % max available memory in bytes per particle
+PredPeakFactor         0.8          % guess for the number of peaks in the subvolume
+
+# outputOptions
+CatalogInAscii                      % catalogs are written in ascii and not in binary format
+OutputInH100                        % units are in H=100 instead of the true H value
+NumFiles               1            % number of files in which each catalog is written
+MinHaloMass            10           % smallest halo that is given in output
+AnalyticMassFunction   9            % form of analytic mass function given in the .mf.out files
+
+# outputFlags
+% WriteSnapshot                     % writes a Gadget2 snapshot as an output
+% DoNotWriteCatalogs                % skips the writing of full catalogs (including PLC)
+% DoNotWriteHistories               % skips the writing of merger histories
+
+# debugFlags
+% WriteFmax                         % writes the values of the Fmax field, particle by particle
+% WriteVmax                         % writes the values of the Vmax field, particle by particle
+% WriteRmax                         % writes the values of the Rmax field, particle by particle
+% WriteDensity                      % writes the linear density, particle by particle
+
+# pastLightCone
+StartingzForPLC        0.3          % starting (highest) redshift for the past light cone
+LastzForPLC            0.0          % final (lowest) redshift for the past light cone
+PLCAperture            30           % cone aperture for the past light cone
+DeltaF_PLC			   0.90			% build_groups.c:102
+% PLCProvideConeData                % read vertex and direction of cone from paramter file
+% PLCCenter 0. 0. 0.                % cone vertex in the same coordinates as the BoxSize
+% PLCAxis   0. 0. 1.                % un-normalized direction of the cone axis

--- a/karabo/test/test_pinocchio.py
+++ b/karabo/test/test_pinocchio.py
@@ -1,18 +1,61 @@
-import os
+import tempfile
 from pathlib import Path
+
+import numpy as np
 
 from karabo.simulation.pinocchio import Pinocchio
 
 
-def test_simple_instance():
-    tmpdir = str(Path("/users", "lmachado", "PINOCCHIOOUTPUT"))
-    p = Pinocchio(working_dir=tmpdir)
-    p.setRunName("test")
-    print(p.paramsInputPath)
-    exit()
-    p.printConfig()
-    p.printRedShiftRequest()
-    p.runPlanner(16, 1)
-    p.run(mpiThreads=2)
+def test_pinocchio_run():
+    """Validate a simple PINOCCHIO run.
 
-    p.save(os.path.join(tmpdir, "subdir"))
+    Verify that PINOCCHIO can run successfully,
+    and check physical outputs against values from
+    previous successful runs.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        p = Pinocchio(working_dir=tmpdir)
+
+        # Store output data for this redshift, in addition to z = 0
+        p.addRedShift("0.3")
+
+        # Load PINOCCHIO parameters from test parameter file
+        pwd = Path(__file__).parent
+        config = p.loadPinocchioConfig(pwd / "pinocchio_params.txt")
+        p.setConfig(config)
+        p.printConfig()
+        p.printRedShiftRequest()
+
+        # Configure run planner, then execute run and save output files
+        p.runPlanner(
+            gbPerNode=16,
+            tasksPerNode=1,
+        )
+        p.run(mpiThreads=2)
+        p.save(tmpdir)
+
+        # Sanity check: number of halos saved at z = 0
+        # This count will always be the same, as long as the random seed stays the same
+        halo_masses = np.loadtxt(
+            Path(tmpdir) / "pinocchio.test.plc.out", unpack=True, usecols=(8,)
+        )
+
+        assert len(halo_masses) == 45711  # Count found from previous run of PINOCCHIO
+
+        # Physical check: verify that Mass Function is close to analytical fit
+        (m, nm, fit) = np.loadtxt(
+            Path(tmpdir) / "pinocchio.0.0000.test.mf.out",
+            unpack=True,
+            usecols=(0, 1, 5),
+        )
+
+        errors = m * nm - m * fit
+        # For this test, we use a small PINOCCHIO run,
+        # in which the mass function diverges for halo masses
+        # above 5 * 10**14 Msun
+        errors = errors[m < 5e14]
+
+        # Threshold chosen to be a small error margin,
+        # in order to verify that PINOCCHIO successfully
+        # reproduces analytical fit to the halo mass function
+        assert np.sum(errors**2) < 1e-6

--- a/karabo/test/test_pinocchio.py
+++ b/karabo/test/test_pinocchio.py
@@ -1,50 +1,18 @@
-import datetime
 import os
-import tempfile
+from pathlib import Path
 
-from karabo.imaging.imager import Imager
-from karabo.simulation.interferometer import InterferometerSimulation
-from karabo.simulation.observation import Observation
 from karabo.simulation.pinocchio import Pinocchio
-from karabo.simulation.telescope import Telescope
 
 
 def test_simple_instance():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        p = Pinocchio(working_dir=tmpdir)
-        p.setRunName("test")
-        p.printConfig()
-        p.printRedShiftRequest()
-        p.runPlanner(16, 1)
-        p.run(mpiThreads=2)
+    tmpdir = str(Path("/users", "lmachado", "PINOCCHIOOUTPUT"))
+    p = Pinocchio(working_dir=tmpdir)
+    p.setRunName("test")
+    print(p.paramsInputPath)
+    exit()
+    p.printConfig()
+    p.printRedShiftRequest()
+    p.runPlanner(16, 1)
+    p.run(mpiThreads=2)
 
-        p.save(os.path.join(tmpdir, "subdir"))
-        sky = p.getSkyModel()
-        sky = sky.filter_by_radius(0, 1, 32, 45)
-
-        telescope = Telescope.get_SKA1_MID_Telescope()
-
-        simulation = InterferometerSimulation(
-            channel_bandwidth_hz=1e3, time_average_sec=10
-        )
-
-        observation = Observation(
-            start_frequency_hz=1e9,
-            phase_centre_ra_deg=31.9875,
-            phase_centre_dec_deg=45.1333,
-            length=datetime.timedelta(minutes=10),
-            number_of_time_steps=1,
-            frequency_increment_hz=1,
-            number_of_channels=1,
-            start_date_and_time="2022-03-01T11:00:00",
-        )
-
-        visibility = simulation.run_simulation(telescope, sky, observation)
-
-        cellsize = 0.003
-        boxsize = 2048
-        imager = Imager(visibility, imaging_npixel=boxsize, imaging_cellsize=cellsize)
-
-        dirty = imager.get_dirty_image()
-        dirty.write_to_file(os.path.join(tmpdir, "dirty.fits"), overwrite=True)
-        dirty.plot("pinocchio sim dirty plot")
+    p.save(os.path.join(tmpdir, "subdir"))


### PR DESCRIPTION
This PR adds `assert` statements to the PINOCCHIO test, and introduces a sample parameter file to be used by the test.
Also, it removes the `getSkyModel` functions from the `PINOCCHIO` class, which were incorrectly assuming that dark matter halos can be used as HI source objects.

Closes #325
Closes #473