### PR TITLE
fixed install commands doc for WSL2

### DIFF
--- a/doc/src/development.md
+++ b/doc/src/development.md
@@ -26,12 +26,17 @@ Then create a local development environment with the provided `environment.yaml`
 
 ```shell
 conda env create -n <your-env-name> -f environment.yaml
+conda activate <your-env-name>
+```
+
+In case you're using WSL2, do the following (see [issue 550](https://github.com/i4Ds/Karabo-Pipeline/issues/550)):
+```shell
+conda env config vars set LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/wsl/lib
 ```
 
 Then install Karabo as a package and the according dev-dependencies.
 
 ```shell
-conda activate <your-env-name>
 pip install -e ".[dev]"
 ```
 

--- a/doc/src/installation_user.md
+++ b/doc/src/installation_user.md
@@ -23,9 +23,11 @@ conda config --env --set solver libmamba
 conda config --env --set channel_priority true
 # install karabo
 conda install -c nvidia/label/cuda-11.7.0 -c i4ds -c conda-forge karabo-pipeline
+# in case you use wsl2
+conda env config vars set LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/wsl/lib
 ```
 
-Karabo versions older than `v0.15.0` are deprecated and therefore installation will most likely fail. In addition, we do not support Karabo older than latest-minor version in case dependency resolving or online resources are outdated. Therefore, we strongly recommend using the latest version of Karabo. If an older version of Karabo is required, we strongly recommend using a [container](container.md), as the environment is fixed in a container. However, outdated online resources may still occur.
+Karabo versions older than `v0.15.0` are deprecated and therefore installation will most likely fail. In addition, we do not support Karabo older than latest-minor version in case dependency resolving or online resources are outdated. Therefore, we strongly recommend using the latest version of Karabo. If an older version of Karabo is required, we recommend using a [container](container.md), as the environment is fixed in a container, or extract the environment dependencies using `conda env export --no-builds`. However, outdated online resources may still occur.
 
 ## Update to latest Karabo version
 A Karabo installation can be updated the following way:
@@ -39,8 +41,3 @@ conda update -c nvidia/label/cuda-11.7.0 -c i4ds -c conda-forge karabo-pipeline
 ## Additional Notes and Troubleshooting
 - Dont' install anything into the base environment except libraries which are supposed to live in there. If you accientally install packages there which are not supposed to be there, you might break some functionalities of your conda-installation.
 - If you're using a system conda, it might be that you don't have access to a libmamba-solver, because the solver lives in the base environment, which belongs to root. In this case, you can ask your admin to install the solver, try an installation without the libmamba solver OR we recommend to just install conda into your home (which is the recommended solution).
-- If you are using WSL and running a jupyter-notebook fails, you might have to set the path to the cuda libraries as follows:
-
-```shell
-conda env config vars set LD_LIBRARY_PATH=/usr/lib/wsl/lib
-```


### PR DESCRIPTION
closes #550 

Hotfix to link shared libraries like cuda in `/usr/lib/wsl/lib`. Properly linking using `ldconfig` doesn't work, because NVIDIA doesn't  install `libcuda.so.1` as a symlink (see https://forums.developer.nvidia.com/t/wsl2-libcuda-so-and-libcuda-so-1-should-be-symlink/236301)