### PR TITLE
splitted ltm- and stm-memory roots for FileHandler to avoid tmp-clear…

### DIFF
--- a/karabo/test/test_filehandler.py
+++ b/karabo/test/test_filehandler.py
@@ -10,7 +10,8 @@ from karabo.util.file_handler import FileHandler
 def test_file_handler():
     """Test global FileHanlder functionality."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        FileHandler.root = tmpdir
+        os.environ["XDG_CACHE_HOME"] = tmpdir  # sets LTM
+        FileHandler.root_stm = tmpdir
         assert FileHandler.is_dir_empty(dirname=tmpdir)
         assert len(os.listdir(tmpdir)) == 0
         tmpdir_fh1 = FileHandler().get_tmp_dir(
@@ -74,7 +75,8 @@ def test_object_bound_file_handler():
         ...
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        FileHandler.root = tmpdir
+        FileHandler.root_stm = tmpdir
+        FileHandler.root_ltm = tmpdir
         my_obj = MyClass()
         assert not os.path.exists(FileHandler.stm())
         tmpdir_fh1 = FileHandler().get_tmp_dir(unique=my_obj)

--- a/karabo/test/test_filehandler.py
+++ b/karabo/test/test_filehandler.py
@@ -10,7 +10,7 @@ from karabo.util.file_handler import FileHandler
 def test_file_handler():
     """Test global FileHanlder functionality."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        os.environ["XDG_CACHE_HOME"] = tmpdir  # sets LTM
+        FileHandler.root_ltm = tmpdir
         FileHandler.root_stm = tmpdir
         assert FileHandler.is_dir_empty(dirname=tmpdir)
         assert len(os.listdir(tmpdir)) == 0


### PR DESCRIPTION
Split long-term-memory disk-cache root from short-term-memory. The reason for this change is because before a differentiation between the two use-cases regarding the root-directory was not possible. Therefore, the default root-dir /tmp caused to remove long-term-memory files at each restart, which is not desired.

- The previous root is now the default for short-term-memory
- Long-term-memory directory now follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).