### PR TITLE
Added wsclean dependency to meta.yaml

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -55,6 +55,7 @@ requirements:
     - ska-sdp-datamodels      =0.1.3
     - ska-sdp-func-python     =0.1.4
     - tools21cm               =2.0.2
+    - wsclean
     - xarray                  >=2022.11
     # transversal dependencies which we need to reference to get mpi-wheels
     - conda-forge::fftw       =*=mpi_mpich*

--- a/environment.yaml
+++ b/environment.yaml
@@ -45,4 +45,3 @@ dependencies:
   # transversal dependencies which we need to reference to get mpi-wheels
   # casacore hast just no-mpi & open-mpi, but no mpich-wheel
   - conda-forge::fftw       =*=mpi_mpich*  # oskarpy(oskar(casacore)), tools21cm, bluebild(finufft) -> from conda-forge to ignore channel-prio & not take our legacy fftw-wheel
-  - fftw3f                  =*=mpi_mpich*


### PR DESCRIPTION
The wsclean conda package is currently not installed when installing the current karabo-pipeline released. This PR should fix this.