### PR TITLE
Object id exported to wrong column name

### DIFF
--- a/karabo/simulation/sky_model.py
+++ b/karabo/simulation/sky_model.py
@@ -1486,9 +1486,9 @@ class SkyModel:
                 "major axis FWHM (arcsec)",
                 "minor axis FWHM (arcsec)",
                 "position angle (deg)",
-                "source id (object)",
                 "true redshift",
                 "observed redshift",
+                "source id (object)",
             ],
         )
 


### PR DESCRIPTION
When exporting a sky model to csv file via `save_sky_model_as_csv()` the object id was written into the wrong column (`observed redshift` instead of `source id (object)`. This PR fixes this.