### PR TITLE
exclude buggy setuptools version :collision:

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     # transversal dependencies which we need to reference to get mpi-wheels
     - conda-forge::fftw       =*=mpi_mpich*
     # exclude buggy versions of other tools
-    - setuptools              <71.0.0,>71.0.2  # buggy with `importlib_metadata`
+    - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
 
 test:
   imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -60,7 +60,8 @@ requirements:
     - xarray                  >=2022.11
     # transversal dependencies which we need to reference to get mpi-wheels
     - conda-forge::fftw       =*=mpi_mpich*
-
+    # exclude buggy versions of other tools
+    - setuptools              <71.0.0,>71.0.2  # buggy with `importlib_metadata`
 
 test:
   imports:

--- a/environment.yaml
+++ b/environment.yaml
@@ -48,4 +48,4 @@ dependencies:
   # casacore hast just no-mpi & open-mpi, but no mpich-wheel
   - conda-forge::fftw       =*=mpi_mpich*  # oskarpy(oskar(casacore)), tools21cm, bluebild(finufft) -> from conda-forge to ignore channel-prio & not take our legacy fftw-wheel
   # exclude buggy versions of other tools
-  - setuptools              <71.0.0,>71.0.2  # buggy with `importlib_metadata`
+  - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`

--- a/environment.yaml
+++ b/environment.yaml
@@ -47,3 +47,5 @@ dependencies:
   # transversal dependencies which we need to reference to get mpi-wheels
   # casacore hast just no-mpi & open-mpi, but no mpich-wheel
   - conda-forge::fftw       =*=mpi_mpich*  # oskarpy(oskar(casacore)), tools21cm, bluebild(finufft) -> from conda-forge to ignore channel-prio & not take our legacy fftw-wheel
+  # exclude buggy versions of other tools
+  - setuptools              <71.0.0,>71.0.2  # buggy with `importlib_metadata`


### PR DESCRIPTION
Fixes current failing tests due to a bug of `setuptools` regarding `importlib_metadata`.