### PR TITLE
Fix error with wrong FITS header card

### DIFF
--- a/karabo/imaging/imager_oskar.py
+++ b/karabo/imaging/imager_oskar.py
@@ -121,6 +121,11 @@ class OskarDirtyImager(DirtyImager):
         image.header["NAXIS"] = 4
         image.header["NAXIS4"] = 1
 
+        # This card is not set correctly by OSKAR. It sets the value to 0.0 which
+        # prevents the calculation of the world coordinate system later on.
+        # Using the value from RASCIL imager, which sets it correctly.
+        image.header.set("CDELT3", 1.0, "Coordinate increment at reference point")
+        
         image.write_to_file(path=output_fits_path, overwrite=True)
 
         return image


### PR DESCRIPTION
## Summary
This fixes an error that made OSKAR imager crash when plotting a dirty image.

## What happend
Use the OSKAR imager to calculate a dirty image:
```
oskar_imager = OskarDirtyImager(
    OskarDirtyImagerConfig(
        imaging_npixel=image_npixel,
        imaging_cellsize=cellsize,
        combine_across_frequencies=True,
    )
)

oskar_dirty_image = oskar_imager.create_dirty_image(visibility)
```

Now save the image in PNG format:
```
oskar_dirty_image.plot(title="OSKAR dirty image", filename="oskar_dirty.png")
```

Before the fix an exception is raised:
```
Traceback (most recent call last):
  File "/home/andreas/karabo/sandbox/debug/debug.py", line 60, in <module>
    oskar_dirty_image.plot(title="OSKAR dirty image", filename="oskar_dirty.png")
  File "/home/andreas/karabo/src/Karabo-Pipeline/karabo/imaging/image.py", line 405, in plot
    wcs = WCS(self.header)
  File "/home/andreas/miniconda3/envs/karabo/lib/python3.9/site-packages/astropy/wcs/wcs.py", line 549, in __init__
    self.wcs.set()
astropy.wcs._wcs.SingularMatrixError: ERROR 3 in wcsset() at line 2775 of file cextern/wcslib/C/wcs.c:
Linear transformation matrix is singular.
ERROR 3 in linset() at line 674 of file cextern/wcslib/C/lin.c:
PCi_ja matrix is singular.
```

## What is fixed
With this fix, the `plot()` function writes the image to disk without throwing an exception.

The cause was a wrong value in the FITS header card `CDELT3`. It was set by OSKAR to 0.0. This resulted in a singlular transformation matrix when calculating the world coordinate system. I assume this is bug in OSKAR code itself,