### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
       - name: Create Environment

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          mamba-version: "*"
+          channels: conda-forge
+          channel-priority: "true"
+          conda-remove-defaults: "true"
       - name: Create Environment
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test-user-package.yml
+++ b/.github/workflows/test-user-package.yml
@@ -37,6 +37,11 @@ jobs:
     steps:
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
+        with:
+          mamba-version: "*"
+          channels: conda-forge
+          channel-priority: "true"
+          conda-remove-defaults: "true"
       - name: Set variables, Install Package & Dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test-user-package.yml
+++ b/.github/workflows/test-user-package.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
       - name: Set variables, Install Package & Dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           mamba-version: "*"
           channels: conda-forge
           channel-priority: true
+          conda-remove-defaults: true
       - name: Install Deps
         shell: bash -el {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           mamba-version: "*"
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: true
       - name: Install Deps
         shell: bash -el {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          mamba-version: "*"
       - name: Install Deps
         shell: bash -el {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
       - name: Install Deps
         shell: bash -el {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           mamba-version: "*"
           channels: conda-forge
-          channel-priority: true
-          conda-remove-defaults: true
+          channel-priority: "true"
+          conda-remove-defaults: "true"
       - name: Install Deps
         shell: bash -el {0}
         run: |


### PR DESCRIPTION
Due to changes to the `conda-incubator/setup-miniconda` workflow running the actions `test` and `build-docks` failed. This PR fixes the issue by updating our actions to `conda-incubator/setup-miniconda@v3`.

### Summary

| Action   | Updated? | Tested? | Comment |
|----------|------------|--------|--------|
| Tests | yes | yes |
| Build Docs | yes | yes |
| Test User Package | yes | no | I didn't dare to test |
| Build Docker Image | no | no | Doesn't use setup-miniconda |
| Conda Build | no | no | Doesn't use setup-miniconda |
| Dev Workflow | no | no | Doesn't use setup-miniconda |
| pages-build-deployment | no | yes | Successful run after 'Build Docs' |
