### PR TITLE
Workflow Update

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -33,7 +33,7 @@ jobs:
           sphinx-apidoc . -o _build
           make html
       - name: Archive doc build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs_built
           path: _deploy


### PR DESCRIPTION
The action `actions/upload-artifact` required an updated from v3 -> v4, because v3 is depricated since Jan 30, 2025. There is no transition period. Hence, the workflow fails. This was fixed in this PR.