### PR TITLE
SP-5327/CHOC-232 MWA ObsCore metadata improvements

### DIFF
--- a/karabo/data/obscore.py
+++ b/karabo/data/obscore.py
@@ -542,11 +542,11 @@ class ObsCoreMeta:
                     nrow=300000000,  # to avoid memory & time issues, should be repres
                 )
             )
-            ocm.t_xel = len(np.unique(MSMainTable.get_col(
-                ms_path=vis_inode,
-                col="TIME",
-                nrow=300000000
-            )))
+            ocm.t_xel = len(
+                np.unique(
+                    MSMainTable.get_col(ms_path=vis_inode, col="TIME", nrow=300000000)
+                )
+            )
             spectral_window = ms_meta.spectral_window
             # wavelength = c/f, min is the highest frequency, max is the lowest
             ocm.em_max = c / np.min(

--- a/karabo/data/obscore.py
+++ b/karabo/data/obscore.py
@@ -495,6 +495,10 @@ class ObsCoreMeta:
 
         Returns:
             `ObsCoreMeta` instance.
+
+        Updated 2025-04-01:
+            - em_min is now less than em_max
+            - t_xel is now the number of unique time-steps, not the number of rows
         """
         ocm = cls(dataproduct_type="visibility")
         vis_inode = vis.path
@@ -542,12 +546,17 @@ class ObsCoreMeta:
                     nrow=300000000,  # to avoid memory & time issues, should be repres
                 )
             )
-            ocm.t_xel = MSMainTable.nrows(ms_path=vis_inode)
+            ocm.t_xel = len(np.unique(MSMainTable.get_col(
+                ms_path=vis_inode,
+                col="TIME",
+                nrow=300000000
+            )))
             spectral_window = ms_meta.spectral_window
-            ocm.em_min = c / np.min(
+            # wavelength = c/f, min is the highest frequency, max is the lowest
+            ocm.em_max = c / np.min(
                 spectral_window.chan_freq - spectral_window.chan_width / 2
             )
-            ocm.em_max = c / np.max(
+            ocm.em_min = c / np.max(
                 spectral_window.chan_freq + spectral_window.chan_width / 2
             )
             ocm.em_res_power = np.median(
@@ -590,22 +599,17 @@ class ObsCoreMeta:
             min_freq_hz = freq_start_hz - channel_bandwidth_hz / 2
             n_channels = header.num_channels_total
             max_freq_hz = min_freq_hz + freq_inc_hz * n_channels
-            min_wavelength_m = c / min_freq_hz
-            ocm.em_min = min_wavelength_m
-            max_wavelength_m = c / max_freq_hz
+            # wavelength = c/f, min is the highest frequency, max is the lowest
+            max_wavelength_m = c / min_freq_hz
             ocm.em_max = max_wavelength_m
+            min_wavelength_m = c / max_freq_hz
+            ocm.em_min = min_wavelength_m
             if freq_inc_hz != 0:
                 midpoint_frequency_hz = (freq_start_hz + max_freq_hz) / 2
                 ocm.em_res_power = midpoint_frequency_hz / freq_inc_hz
             ocm.em_xel = n_channels
             if tel is not None and (tel_name := tel.name) is not None:
                 ocm.instrument_name = tel_name
-            if tel is not None and obs is not None:
-                freq_inc_hz = obs.frequency_increment_hz
-                min_freq_hz = obs.start_frequency_hz - freq_inc_hz / 2
-                end_freq_hz = min_freq_hz + freq_inc_hz * obs.number_of_channels
-                b = float(tel.max_baseline())
-                ocm.s_resolution = tel.ang_res(freq=end_freq_hz, b=b)
         else:
             assert_never(vis.format)
         ocm.access_estsize = int(getsize(inode=vis_inode) / 1e3)  # B -> KB

--- a/karabo/data/obscore.py
+++ b/karabo/data/obscore.py
@@ -495,10 +495,6 @@ class ObsCoreMeta:
 
         Returns:
             `ObsCoreMeta` instance.
-
-        Updated 2025-04-01:
-            - em_min is now less than em_max
-            - t_xel is now the number of unique time-steps, not the number of rows
         """
         ocm = cls(dataproduct_type="visibility")
         vis_inode = vis.path

--- a/karabo/simulation/telescope.py
+++ b/karabo/simulation/telescope.py
@@ -937,6 +937,6 @@ but was not provided. Please provide a value for the version field."
         Returns:
             Angular resolution in arcsec.
         """
-        ang_res = (const.c.value / freq) / b * u.deg
+        ang_res = (const.c.value / freq) / b * u.rad
         ang_res_arcsec: float = ang_res.to(u.arcsec).value
         return ang_res_arcsec

--- a/karabo/test/test_obscore.py
+++ b/karabo/test/test_obscore.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import numpy as np
 import pytest
+from astropy import constants as const
 from astropy import units as u
 from astropy.time import Time
-from astropy import constants as const
 from pytest import FixtureRequest
 from rfc3986.exceptions import InvalidComponentsError
 
@@ -162,11 +162,23 @@ class TestObsCoreMeta:
         assert ocm.calib_level == 1  # because `calibrated` flag set to False
         assert ocm.instrument_name is not None
         assert ocm.s_resolution is not None and ocm.s_resolution > 0.0
-        assert ocm.em_res_power is not None and ocm.em_res_power > 1.0 # λ/δλ>1
+        assert ocm.em_res_power is not None and ocm.em_res_power > 1.0  # λ/δλ>1
 
         allowed_pols = [
-            "I", "Q", "U", "V", "RR", "LL", "RL", "LR", "XX", "YY", "XY", "YX",
-            "POLI", "POLA"
+            "I",
+            "Q",
+            "U",
+            "V",
+            "RR",
+            "LL",
+            "RL",
+            "LR",
+            "XX",
+            "YY",
+            "XY",
+            "YX",
+            "POLI",
+            "POLA",
         ]
         if visibility.format != "OSKAR_VIS":
             assert ocm.pol_xel is not None and ocm.pol_xel > 0

--- a/karabo/test/test_obscore.py
+++ b/karabo/test/test_obscore.py
@@ -153,13 +153,8 @@ class TestObsCoreMeta:
         assert ocm.em_min is not None and ocm.em_min > 0.0
         assert ocm.em_max is not None and ocm.em_max > 0.0
         assert ocm.em_max > ocm.em_min
-        if visibility.format == "OSKAR_VIS":
-            # there's an issue with minimal_casa_ms
-            # > tb.open('test_minimal_casa.ms/SPECTRAL_WINDOW')
-            # > tb.getcol('CHAN_FREQ')
-            # array([[7.600e+07],[1.760e+08],...[1.476e+09],[1.576e+09]])
-            assert ocm.em_min == exp_em_min
-            assert ocm.em_max == exp_em_max
+        assert ocm.em_min == exp_em_min
+        assert ocm.em_max == exp_em_max
         assert ocm.em_xel is not None and ocm.em_xel == exp_nfreqs
         assert ocm.access_estsize is not None and ocm.access_estsize > 0.0
         assert ocm.em_ucd is not None

--- a/karabo/test/test_obscore.py
+++ b/karabo/test/test_obscore.py
@@ -8,6 +8,8 @@ from typing import Any
 import numpy as np
 import pytest
 from astropy import units as u
+from astropy.time import Time
+from astropy import constants as const
 from pytest import FixtureRequest
 from rfc3986.exceptions import InvalidComponentsError
 
@@ -111,16 +113,22 @@ class TestObsCoreMeta:
         request: FixtureRequest,
     ) -> None:
         visibility: Visibility = request.getfixturevalue(vis_fixture_name)
+        exp_time_start, exp_ntimes = datetime(2024, 3, 15, 10, 46, 0), 24
+        exp_time_res = 600.0
+        exp_freq_start, exp_freq_res, exp_nfreqs = 100e6, 1e6, 16
+        exp_em_max = const.c.value / 99.5e6
+        exp_em_min = const.c.value / 115.5e6
+        exp_ra, exp_dec = 250.0, -80.0
         if visibility.format == "OSKAR_VIS":
             telescope = Telescope.constructor("ASKAP", backend=SimulatorBackend.OSKAR)
             observation = Observation(  # original settings for `minimal_oskar_vis`
-                start_frequency_hz=100e6,
-                start_date_and_time=datetime(2024, 3, 15, 10, 46, 0),
-                phase_centre_ra_deg=250.0,
-                phase_centre_dec_deg=-80.0,
-                number_of_channels=16,
-                frequency_increment_hz=1e6,
-                number_of_time_steps=24,
+                start_frequency_hz=exp_freq_start,
+                start_date_and_time=exp_time_start,
+                phase_centre_ra_deg=exp_ra,
+                phase_centre_dec_deg=exp_dec,
+                number_of_channels=exp_nfreqs,
+                frequency_increment_hz=exp_freq_res,
+                number_of_time_steps=exp_ntimes,
             )
         else:
             telescope = None
@@ -132,29 +140,50 @@ class TestObsCoreMeta:
             obs=observation,
         )
         assert ocm.dataproduct_type == "visibility"
-        assert ocm.s_ra is not None and np.allclose(ocm.s_ra, 250.0)
-        assert ocm.s_dec is not None and np.allclose(ocm.s_dec, -80.0)
-        assert ocm.t_min is not None
+        assert ocm.s_ra is not None and np.allclose(ocm.s_ra, exp_ra)
+        assert ocm.s_dec is not None and np.allclose(ocm.s_dec, exp_dec)
+        assert ocm.t_min is not None and np.isclose(ocm.t_min, Time(exp_time_start).mjd)
         assert ocm.t_max is not None and ocm.t_max > ocm.t_min
         assert ocm.t_exptime is not None and ocm.t_exptime > 0.0
         assert ocm.t_resolution is not None and ocm.t_resolution > 0.0
-        assert ocm.t_xel is not None
+        assert ocm.t_exptime >= ocm.t_resolution
+        assert np.isclose(ocm.t_resolution, exp_time_res)
+        assert np.isclose(ocm.t_exptime, exp_ntimes * exp_time_res)
+        assert ocm.t_xel is not None and ocm.t_xel == exp_ntimes
         assert ocm.em_min is not None and ocm.em_min > 0.0
-        assert (
-            ocm.em_max is not None and ocm.em_max > 0.0 and ocm.em_max <= ocm.em_min
-        )  # <= because max-freq = min-wavelength
-        assert ocm.em_xel is not None and ocm.em_xel >= 1
+        assert ocm.em_max is not None and ocm.em_max > 0.0
+        assert ocm.em_max > ocm.em_min
+        if visibility.format == "OSKAR_VIS":
+            # there's an issue with minimal_casa_ms
+            # > tb.open('test_minimal_casa.ms/SPECTRAL_WINDOW')
+            # > tb.getcol('CHAN_FREQ')
+            # array([[7.600e+07],[1.760e+08],...[1.476e+09],[1.576e+09]])
+            assert ocm.em_min == exp_em_min
+            assert ocm.em_max == exp_em_max
+        assert ocm.em_xel is not None and ocm.em_xel == exp_nfreqs
         assert ocm.access_estsize is not None and ocm.access_estsize > 0.0
         assert ocm.em_ucd is not None
         assert ocm.o_ucd is not None
         assert ocm.calib_level == 1  # because `calibrated` flag set to False
         assert ocm.instrument_name is not None
         assert ocm.s_resolution is not None and ocm.s_resolution > 0.0
+        assert ocm.em_res_power is not None and ocm.em_res_power > 1.0 # λ/δλ>1
 
-        if visibility.format == "MS":
+        allowed_pols = [
+            "I", "Q", "U", "V", "RR", "LL", "RL", "LR", "XX", "YY", "XY", "YX",
+            "POLI", "POLA"
+        ]
+        if visibility.format != "OSKAR_VIS":
             assert ocm.pol_xel is not None and ocm.pol_xel > 0
             assert ocm.pol_states is not None and len(ocm.pol_states) > 0
+            assert ocm.pol_states.startswith("/")
+            assert ocm.pol_states.endswith("/")
+            pols = [*filter(None, ocm.pol_states.split("/"))]
+            assert len(pols) == ocm.pol_xel
+            for pol in pols:
+                assert pol in allowed_pols
 
+        # test serialization
         with tempfile.TemporaryDirectory() as tmpdir:
             meta_path = os.path.join(tmpdir, "obscore-vis.json")
             with pytest.warns(UserWarning):  # mandatory fields not set

--- a/karabo/test/test_telescope.py
+++ b/karabo/test/test_telescope.py
@@ -3,8 +3,11 @@ import pathlib as pl
 import tempfile
 from unittest import mock
 
+
 import pytest
 from ska_sdp_datamodels.configuration.config_model import Configuration
+from astropy import constants as const
+import numpy as np
 
 from karabo.simulation.telescope import Telescope
 from karabo.simulation.telescope_versions import (
@@ -239,3 +242,15 @@ def test_plot_invalid_backend(mock_logging_warning):
     # Attempt plotting, which triggers logging but no plot
     tel.plot_telescope()
     assert mock_logging_warning.call_count == 1
+
+def test_ang_res():
+    """
+    At 1m wavelength, a 1km baseline resolves 1/1000rad => 206asec
+    """
+    wavelength = 1 # 1m
+    freq = (const.c.value / wavelength)
+    b = 1000 # 1km
+    exp_ang_res_radians = wavelength / b
+    exp_ang_res_arcsec = (exp_ang_res_radians * 180 * 3600) / np.pi
+    ang_res_arcsec = Telescope.ang_res(freq, b)
+    assert np.isclose(ang_res_arcsec, exp_ang_res_arcsec, rtol=1e-5), f"Expected {exp_ang_res_arcsec}, got {ang_res_arcsec}"

--- a/karabo/test/test_telescope.py
+++ b/karabo/test/test_telescope.py
@@ -3,11 +3,10 @@ import pathlib as pl
 import tempfile
 from unittest import mock
 
-
-import pytest
-from ska_sdp_datamodels.configuration.config_model import Configuration
-from astropy import constants as const
 import numpy as np
+import pytest
+from astropy import constants as const
+from ska_sdp_datamodels.configuration.config_model import Configuration
 
 from karabo.simulation.telescope import Telescope
 from karabo.simulation.telescope_versions import (
@@ -243,14 +242,17 @@ def test_plot_invalid_backend(mock_logging_warning):
     tel.plot_telescope()
     assert mock_logging_warning.call_count == 1
 
+
 def test_ang_res():
     """
     At 1m wavelength, a 1km baseline resolves 1/1000rad => 206asec
     """
-    wavelength = 1 # 1m
-    freq = (const.c.value / wavelength)
-    b = 1000 # 1km
+    wavelength = 1  # 1m
+    freq = const.c.value / wavelength
+    b = 1000  # 1km
     exp_ang_res_radians = wavelength / b
     exp_ang_res_arcsec = (exp_ang_res_radians * 180 * 3600) / np.pi
     ang_res_arcsec = Telescope.ang_res(freq, b)
-    assert np.isclose(ang_res_arcsec, exp_ang_res_arcsec, rtol=1e-5), f"Expected {exp_ang_res_arcsec}, got {ang_res_arcsec}"
+    assert np.isclose(
+        ang_res_arcsec, exp_ang_res_arcsec, rtol=1e-5
+    ), f"Expected {exp_ang_res_arcsec}, got {ang_res_arcsec}"

--- a/karabo/test/test_telescope_baselines.py
+++ b/karabo/test/test_telescope_baselines.py
@@ -132,7 +132,7 @@ def test_telescope_max_baseline_length(
 
     freq_Hz = 100e6
     angular_res: float = Telescope.ang_res(freq_Hz, max_length_oskar)
-    assert math.isclose(angular_res, 1.44, rel_tol=1e-2)
+    assert math.isclose(angular_res, 82.44, rel_tol=1e-2)
 
 
 def test_telescope_stations(oskar_telescope: Telescope, rascil_telescope: Telescope):


### PR DESCRIPTION
This is a draft to show my progress towards SP-5327 - Improve discoverability of MWA data via TAP/Rucio.

So far I've only completed part of choc-232:
- fixed angular resolution calculation for s_resolution
- swap em_min and em_max
- fix calculation of t_xel, number of timesteps

at this point the tests pass, but I noticed an issue with one of the test datasets, and will check with the team what to do about it.

after that I intend to extend the tests to MWA flavoured measurement sets, uvfits, uvh5.