### PR TITLE
[choc-233,234] add MWA uvfits obscore support via pyuvdata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           conda create -y -n test_karabo python=3.9
           conda activate test_karabo
-          mamba env update --file environment.yaml
+          conda env update -f environment.yaml
           pip install -e ".[dev]"
           python -m ipykernel install --user --name python3
       - name: Test Dev-Tools

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -66,8 +66,13 @@ requirements:
     # exclude buggy versions of other tools
     - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
     # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
-    # pinnned to 2.4.1 because later versions use an astropy that needs numpy 2
-    - pyuvdata[casa]          <=2.4.1
+    # pinnned to 2.4.1 because:
+    # - 2.4.2 has a corrupt file in conda-forge
+    # - later versions use an astropy that needs numpy 2
+    - pyuvdata                <=2.4.1
+    # the following enables casacore in python. specifying the above dep as pyuvdata[casa] works in
+    # conda but mamba doesn't understand optional dep syntax
+    - python-casacore         <=3.7.1
 
 test:
   imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -66,13 +66,8 @@ requirements:
     # exclude buggy versions of other tools
     - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
     # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
-    # pinnned to 2.4.1 because:
-    # - 2.4.2 has a corrupt file in conda-forge
-    # - later versions use an astropy that needs numpy 2
-    - pyuvdata                <=2.4.1
-    # the following enables casacore in python. specifying the above dep as pyuvdata[casa] works in
-    # conda but mamba doesn't understand optional dep syntax
-    - python-casacore         <=3.7.1
+    # this [casa] syntax won't work with mamba!
+    - pyuvdata[casa]          >=2.4,<3
 
 test:
   imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -65,6 +65,9 @@ requirements:
     - conda-forge::fftw       =*=mpi_mpich*
     # exclude buggy versions of other tools
     - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
+    # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
+    # pinnned to 2.4.1 because later versions use an astropy that needs numpy 2
+    - pyuvdata[casa]          <=2.4.1
 
 test:
   imports:

--- a/environment.yaml
+++ b/environment.yaml
@@ -53,5 +53,10 @@ dependencies:
   # exclude buggy versions of other tools
   - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
   # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
-  # pinnned to 2.4.1 because later versions use an astropy that needs numpy 2
-  - pyuvdata[casa]          <=2.4.1
+  # pinnned to 2.4.1 because:
+  # - 2.4.2 has a corrupt file in conda-forge
+  # - later versions use an astropy that needs numpy 2
+  - pyuvdata                <=2.4.1
+  # the following enables casacore in python. specifying the above dep as pyuvdata[casa] works in
+  # conda but mamba doesn't understand optional dep syntax
+  - python-casacore         <=3.7.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,7 @@ dependencies:
 # Just Karabo's direct dependencies and Karabo constraints (from our code) should be handled here.
 # Dependencies with unstable APIs (this usually includes Karabo-Feedstock) should be fixed.
 # Don't fix anything regarding build-string (except mpi) here. There's a lot you could do wrong.
-# 
+#
 # IMPORTANT: If you add or remove dependencies, make sure to adjust conda/meta.yaml as well.
   - python                  =3.9
   - aratmospy               =1.0.0
@@ -52,3 +52,6 @@ dependencies:
   - conda-forge::fftw       =*=mpi_mpich*  # oskarpy(oskar(casacore)), tools21cm, bluebild(finufft) -> from conda-forge to ignore channel-prio & not take our legacy fftw-wheel
   # exclude buggy versions of other tools
   - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
+  # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
+  # pinnned to 2.4.1 because later versions use an astropy that needs numpy 2
+  - pyuvdata[casa]          <=2.4.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -53,10 +53,5 @@ dependencies:
   # exclude buggy versions of other tools
   - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
   # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
-  # pinnned to 2.4.1 because:
-  # - 2.4.2 has a corrupt file in conda-forge
-  # - later versions use an astropy that needs numpy 2
-  - pyuvdata                <=2.4.1
-  # the following enables casacore in python. specifying the above dep as pyuvdata[casa] works in
-  # conda but mamba doesn't understand optional dep syntax
-  - python-casacore         <=3.7.1
+  # this [casa] syntax won't work with mamba!
+  - pyuvdata[casa]          >=2.4,<3

--- a/karabo/data/obscore.py
+++ b/karabo/data/obscore.py
@@ -30,13 +30,17 @@ import rfc3986
 import rfc3986.validators
 from astropy import constants as const
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.io.fits.header import Header
+from astropy.time import Time
 from astropy.units.core import UnitBase
 from astropy.units.quantity import Quantity
 from oskar import VisHeader
+from pyuvdata import UVData
+from pyuvdata import __version__ as pyuvdata_version
 from typing_extensions import Self, TypeGuard, assert_never
 
-from karabo.data.casa import MSMainTable, MSMeta, MSPolarizationTable
+from karabo.data.casa import MSPolarizationTable
 from karabo.imaging.image import Image
 from karabo.simulation.observation import Observation
 from karabo.simulation.telescope import Telescope
@@ -479,9 +483,8 @@ class ObsCoreMeta:
         is no possibility to fill all mandatory fields because there is just no
         information available. Thus, you have to take care of some fields by yourself.
 
-        Supported formats: CASA Measurement Sets & OSKAR-vis binary. CASA MS format
-            is preferred since it provides more metadata information compared to
-            OSKAR binaries.
+        Supported formats: CASA Measurement Sets, OSKAR-vis binary, UVFITS.
+        OSKAR binaries provide less metadata, so other formats are preferred.
 
         Args:
             vis: `Visibility` instance.
@@ -502,72 +505,83 @@ class ObsCoreMeta:
             err_msg = f"{vis_inode} doesn't exist!"
             raise FileNotFoundError(err_msg)
         c = const.c.value
-        if vis.format == "MS":
+        if vis.format == "UVFITS" or vis.format == "MS":
+            uvd = UVData()
+            read_kwargs = {}
+            # future array shapes is deprecated after 3.2.0
+            if pyuvdata_version <= "2.2.10":
+                raise NotImplementedError(
+                    "pyuvdata version >= 2.2.10 is required"
+                    " for reading with future array shapes"
+                )
+            elif pyuvdata_version <= "3.2.0":
+                read_kwargs["use_future_array_shapes"] = True
+            uvd.read(vis_inode, **read_kwargs)
             if tel is not None or obs is not None:
                 wmsg = (
                     "Providing `tel` or `obs` in `ObsCoreMeta.from_visibility` for "
-                    + "underlying CASA Measurement Set visibility has no effect!"
+                    + f"{vis.format} visibility file has no effect!"
                 )
                 warn(wmsg, category=UserWarning, stacklevel=2)
-            ms_meta = MSMeta.from_ms(ms_path=vis_inode)
-            field_table = ms_meta.field
-            if not np.all(field_table.num_poly == 0):
+
+            # phase center
+            phase_center_ids = np.unique(uvd.phase_center_id_array)
+            if len(phase_center_ids) > 1:
                 err_msg = (
-                    "Phase-center(s) depicted as polynomials in time is not supported."
+                    f"Multiple phase-centers found in {vis_inode}: {phase_center_ids=}"
                 )
                 raise NotImplementedError(err_msg)
-            if (n_phase_center := field_table.phase_dir.shape[0]) > 1:
-                wmsg = (
-                    f"Found {n_phase_center=} in `ObsCoreMeta.from_visibility` for "
-                    + f"{vis_inode=}. Computing mean/central phase-center!"
-                )
-                warn(wmsg, category=RuntimeWarning, stacklevel=2)
-            phase_dir_deg = np.rad2deg(field_table.phase_dir)
-            phase_dir_deg[:, :, 0] = phase_dir_deg[:, :, 0] % 360  # ensures positive RA
-            phase_center_deg = phase_dir_deg.mean(axis=(0, 1))
-            ocm.s_ra = phase_center_deg[0]
-            ocm.s_dec = phase_center_deg[1]
-            observation = ms_meta.observation
-            time_start_mjd_utc = observation.time_range[:, 0].min() / 86400
-            ocm.t_min = time_start_mjd_utc
-            time_end_mjd_utc = observation.time_range[:, 1].max() / 86400
-            ocm.t_max = time_end_mjd_utc
-            ocm.t_exptime = np.abs(  # abs is just to be sure
-                observation.time_range[:, 1] - observation.time_range[:, 0]
-            ).mean()  # in s, not mjd-utc
-            ocm.t_resolution = np.median(  # chosen repres value over min-interval
-                MSMainTable.get_col(
-                    ms_path=vis_inode,
-                    col="INTERVAL",  # according to MS v2.0
-                    nrow=300000000,  # to avoid memory & time issues, should be repres
-                )
+            phase_center = uvd.phase_center_catalog[phase_center_ids[0]]
+            phase_center = SkyCoord(
+                phase_center["cat_lon"],
+                phase_center["cat_lat"],
+                frame=phase_center["cat_frame"],
+                unit="rad",
             )
-            ocm.t_xel = len(
-                np.unique(
-                    MSMainTable.get_col(ms_path=vis_inode, col="TIME", nrow=300000000)
-                )
-            )
-            spectral_window = ms_meta.spectral_window
-            # wavelength = c/f, min is the highest frequency, max is the lowest
-            ocm.em_max = c / np.min(
-                spectral_window.chan_freq - spectral_window.chan_width / 2
-            )
-            ocm.em_min = c / np.max(
-                spectral_window.chan_freq + spectral_window.chan_width / 2
-            )
-            ocm.em_res_power = np.median(
-                spectral_window.chan_freq / spectral_window.chan_width
-            )
-            ocm.em_xel = spectral_window.chan_freq.ravel().shape[0]
+            ocm.s_ra = phase_center.ra.deg
+            ocm.s_dec = phase_center.dec.deg
+
+            # times
+            times = Time(np.sort(np.unique(uvd.time_array)), format="jd")
+            ocm.t_min = times[0].mjd
+            ocm.t_max = times[-1].mjd
+            ocm.t_resolution = float(np.median(np.diff(times.gps)))
+            ocm.t_xel = len(times)
+            ocm.t_exptime = ocm.t_xel * ocm.t_resolution
+
+            # frequencies
+            freqs = np.unique(uvd.freq_array)
+            half_width = uvd.channel_width / 2
+            ocm.em_min = c / np.max(freqs + half_width)  # em sorted by frequency
+            ocm.em_max = c / np.min(freqs - half_width)
+            ocm.em_res_power = np.median(freqs / uvd.channel_width)
+            ocm.em_xel = len(freqs)
+            # delimited truthy and unique values for instrument name
             ocm.instrument_name = ",".join(
-                np.unique(ms_meta.observation.telescope_name)
+                filter(
+                    None,
+                    np.unique(
+                        [
+                            uvd.instrument,
+                            uvd.telescope_name,
+                        ]
+                    ),
+                )
             )
-            b = float(np.max(ms_meta.antenna.baseline_dists()))
+
+            # spatial resolution
+            b_max = np.max(np.linalg.norm(uvd.uvw_array, axis=1))
             ocm.s_resolution = Telescope.ang_res(
-                freq=float(np.max(spectral_window.ref_frequency)),
-                b=b,
+                freq=float(np.max(freqs)),
+                b=b_max,
             )
-            corr_types = np.unique(ms_meta.polarization.corr_type.ravel()).tolist()
+
+            # polarizations
+            def _validate_pol_str(pol_str: str) -> _PolStatesType:
+                return cast(_PolStatesType, pol_str.upper())
+
+            corr_types = [*map(_validate_pol_str, uvd.get_pols())]
+            # convert string to pol index
             ocm.set_pol_states(pol_states=corr_types)
             pol_states = ocm.get_pol_states()
             if pol_states is not None:

--- a/karabo/simulation/interferometer.py
+++ b/karabo/simulation/interferometer.py
@@ -317,6 +317,8 @@ class InterferometerSimulation:
                 visibility_path = os.path.join(tmp_dir, "measurements.MS")
             elif visibility_format == "OSKAR_VIS":
                 visibility_path = os.path.join(tmp_dir, "visibility.vis")
+            elif visibility_format == "UVFITS":
+                raise KaraboInterferometerSimulationError("unexpected uvfits")
             else:
                 assert_never(visibility_format)
         else:
@@ -346,6 +348,8 @@ class InterferometerSimulation:
                 visibilities_root_dir = os.path.join(tmp_dir, "measurements")
             elif visibility_format == "OSKAR_VIS":
                 visibilities_root_dir = os.path.join(tmp_dir, "visibilities")
+            elif visibility_format == "UVFITS":
+                raise KaraboInterferometerSimulationError("unexpected uvfits")
             else:
                 assert_never(visibility_format)
         os.makedirs(visibilities_root_dir, exist_ok=True)
@@ -639,6 +643,8 @@ class InterferometerSimulation:
         elif visibility_format == "OSKAR_VIS":
             ending = "vis"
             filename_key = "oskar_vis_filename"
+        elif visibility_format == "UVFITS":
+            raise KaraboInterferometerSimulationError("unexpected uvfits")
         else:
             assert_never(visibility_format)
 
@@ -697,6 +703,8 @@ class InterferometerSimulation:
             filename_key = "ms_filename"
         elif visibility_format == "OSKAR_VIS":
             filename_key = "oskar_vis_filename"
+        elif visibility_format == "UVFITS":
+            raise KaraboInterferometerSimulationError("unexpected uvfits")
         else:
             assert_never(visibility_format)
         interferometer_params = self.__get_OSKAR_settings_tree(

--- a/karabo/simulation/visibility.py
+++ b/karabo/simulation/visibility.py
@@ -12,12 +12,14 @@ from karabo.util.file_handler import FileHandler
 
 # If you add a new format, a corresponding path validator function needs to be added
 # to _VISIBILITY_FORMAT_VALIDATORS.
-VisibilityFormat = Literal["MS", "OSKAR_VIS"]
+VisibilityFormat = Literal["MS", "OSKAR_VIS", "UVFITS"]
 _VISIBILITY_FORMAT_VALIDATORS: Final[
     Dict[VisibilityFormat, Callable[[Union[DirPathType, FilePathType]], bool]]
 ] = {
     "MS": lambda path: str(path).lower().endswith(".ms"),
     "OSKAR_VIS": lambda path: str(path).lower().endswith(".vis"),
+    "UVFITS": lambda path: (lower := str(path).lower()).endswith(".uvfits")
+    or lower.endswith(".uvf"),
 }
 assert len(get_args(VisibilityFormat)) == len(_VISIBILITY_FORMAT_VALIDATORS)
 assert all(f in _VISIBILITY_FORMAT_VALIDATORS for f in get_args(VisibilityFormat))

--- a/karabo/test/conftest.py
+++ b/karabo/test/conftest.py
@@ -230,6 +230,28 @@ def minimal_casa_ms() -> Visibility:
 
 
 @pytest.fixture(scope="session")
+def mwa_uvfits() -> Visibility:
+    vis_path = SingleFileDownloadObject(
+        remote_file_path="birli_1061312152_ants0-2_ch154_2s.uvfits",
+        remote_base_url=cscs_karabo_public_testing_base_url,
+    ).get()
+    return Visibility(vis_path)
+
+
+@pytest.fixture(scope="session")
+def mwa_ms() -> Visibility:
+    vis_zip_path = SingleFileDownloadObject(
+        remote_file_path="birli_1061312152_ants0-2_ch154_2s.ms.zip",
+        remote_base_url=cscs_karabo_public_testing_base_url,
+    ).get()
+    vis_path = vis_zip_path.strip(".zip")
+    if not os.path.exists(vis_path):
+        with zipfile.ZipFile(vis_zip_path, "r") as zip_ref:
+            zip_ref.extractall(os.path.dirname(vis_path))
+    return Visibility(vis_path)
+
+
+@pytest.fixture(scope="session")
 def minimal_fits_restored() -> Image:
     restored_path = SingleFileDownloadObject(
         remote_file_path="test_minimal_clean_restored.fits",

--- a/karabo/test/test_notebooks.py
+++ b/karabo/test/test_notebooks.py
@@ -76,7 +76,7 @@ def test_ImageMosaicker_notebook() -> None:
 
 
 @pytest.mark.skipif(
-    not RUN_NOTEBOOK_TESTS,
+    IS_GITHUB_RUNNER or not RUN_NOTEBOOK_TESTS,
     reason="'Error: The operation was canceled' when running this test on the package",
 )
 def test_imaging_notebook() -> None:


### PR DESCRIPTION
- add pyuvdata 2.4.1 as a dependency. currently pinned because for python 3.9 compatibility
- use pyuvdata for ms and uvfits reading
- add small test datasets for mwa ms and uvfits, uploaded to CSCS as test fixtures
- use future array shapes in pyuvdata
- auto-format fixes