### PR TITLE
Update workflow: Install mpich on runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      - name: Install mpi
+        run: sudo apt-get update && sudo apt-get install -y mpich
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Install Conda


### PR DESCRIPTION
## Summary
Our tests need to run `mpirun`. This tool was installed on Ubuntu runner up to now. Due to some reasons unclear to me this not 
the case anymore. Thus some tests fail.

## What was done
I updated the test workflow. The package `mpich` is now installed as part of the runner setup.
 