### PR TITLE
Fix Conda build pipeline

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -97,10 +97,7 @@ jobs:
       - name: Publish to Conda
         shell: bash -l {0}
         run: |
-          echo "************* DEBUG: Get installed anaconda"
-          which anaconda
-          anaconda --help
-          anaconda -t ${{ secrets.ANACONDA_SECRET }} upload /usr/share/miniconda/envs/test/conda-bld/linux-64/karabo-pipeline-*.conda --force
+          conda run -n base anaconda -t ${{ secrets.ANACONDA_SECRET }} upload /usr/share/miniconda/conda-bld/linux-64/karabo-pipeline-*.conda --force
 
   test-conda-wheel:
     needs: conda-build

--- a/.github/workflows/test-conda-wheel.yml
+++ b/.github/workflows/test-conda-wheel.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           mamba-version: "*"
           channels: conda-forge

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,6 +15,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
     - numpy
   host:
     - python                  {{ python }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   build:
     - python
-    - setuptools
+    - setuptools              >=69.0.0,<81,!=71.0.0,!=71.0.1,!=71.0.2
     - numpy
   host:
     - python                  {{ python }}
@@ -65,7 +65,8 @@ requirements:
     # transversal dependencies which we need to reference to get mpi-wheels
     - conda-forge::fftw       =*=mpi_mpich*
     # exclude buggy versions of other tools
-    - setuptools              !=71.0.0, !=71.0.1, !=71.0.2  # buggy with `importlib_metadata`
+    # <81: setuptools>=81 removed bundled `pkg_resources`, which ska_sdp_datamodels and karabo code still import
+    - setuptools              >=69.0.0,<81,!=71.0.0,!=71.0.1,!=71.0.2  # 71.0.0-71.0.2 buggy with `importlib_metadata`
     # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
     # this [casa] syntax won't work with mamba!
     - pyuvdata[casa]          >=2.4,<3

--- a/environment.yaml
+++ b/environment.yaml
@@ -55,7 +55,8 @@ dependencies:
   # casacore hast just no-mpi & open-mpi, but no mpich-wheel
   - conda-forge::fftw       =*=mpi_mpich*  # oskarpy(oskar(casacore)), tools21cm, bluebild(finufft) -> from conda-forge to ignore channel-prio & not take our legacy fftw-wheel
   # exclude buggy versions of other tools
-  - setuptools              >=69.0.0,<70.0.0  # pkg_resources required by ska_sdp_datamodels and karabo code
+  # <81: setuptools>=81 removed bundled `pkg_resources`, which ska_sdp_datamodels and karabo code still import
+  - setuptools              >=69.0.0,<81,!=71.0.0,!=71.0.1,!=71.0.2  # 71.0.0-71.0.2 buggy with `importlib_metadata`
   # for MWA measurement set, uvfits, hdf5, mir support (choc-234)
   # this [casa] syntax won't work with mamba!
   - pyuvdata[casa]          >=2.4,<3


### PR DESCRIPTION
This PR fixes issue #683. I had to pin down the version for setuptools <81, because after that the module `pkg_resources` was removed. But it was required by our old version of ska-sdp package. This should become obsolete once we upgrade it to the latest version.