### PR TITLE
Run CI dev-tools and tests inside the conda env via `conda run`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,10 @@ jobs:
         run: |
           conda create -y -n test_karabo python=3.10
           conda env update -n test_karabo -f environment.yaml --prune
-          conda install -y -n test_karabo pybind11 ipykernel
+          # `pip` is not listed in environment.yaml, so `conda env update
+          # --prune` strips it from the env; reinstall it alongside the build
+          # deps so the absolute-path `python -m pip` below works.
+          conda install -y -n test_karabo pybind11 ipykernel pip
           # Address the env by the absolute path to its interpreter. `conda
           # activate` / `conda run -n` proved unreliable on the runner: they
           # silently resolved to a different Python, so dev tools were installed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,32 +49,34 @@ jobs:
         run: |
           conda create -y -n test_karabo python=3.10
           conda env update -n test_karabo -f environment.yaml --prune
-          conda activate test_karabo
-          conda install -y pybind11 ipykernel
-          python -m ipykernel install --user --name python3.10
-          pip install -e ".[dev]"
+          conda install -y -n test_karabo pybind11 ipykernel
+          # Run tools via `conda run -n test_karabo` so they execute inside the
+          # env's Python 3.10 interpreter. `conda activate` is unreliable in the
+          # runner shell and silently falls back to system Python, which breaks
+          # type checking (dask/xarray missing -> spurious mypy errors).
+          conda run -n test_karabo --no-capture-output \
+            python -m ipykernel install --user --name python3.10
+          conda run -n test_karabo --no-capture-output pip install -e ".[dev]"
 
           # Debug since we had problems with mpi installation
-          python -c "import h5py; print('h5py ok')"
+          conda run -n test_karabo --no-capture-output python -c "import h5py; print('h5py ok')"
           which wsclean || true
-          ldd "$(which wsclean)" | grep -i mpi || tru  
+          ldd "$(which wsclean)" | grep -i mpi || true
 
       - name: Test Dev-Tools
         shell: bash -el {0}
         run: |
-          conda activate test_karabo
-          flake8 .
-          black --check .
-          isort --check .
-          mypy .
+          conda run -n test_karabo --no-capture-output flake8 .
+          conda run -n test_karabo --no-capture-output black --check .
+          conda run -n test_karabo --no-capture-output isort --check .
+          conda run -n test_karabo --no-capture-output mypy .
 
       - name: Test Code
         shell: bash -el {0}
         run: |
           export IS_GITHUB_RUNNER=true RUN_GPU_TESTS=false RUN_NOTEBOOK_TESTS=true
-          conda activate test_karabo
-          mpirun -n 2 pytest --only-mpi
-          pytest --cov=./ --cov-report=xml
+          conda run -n test_karabo --no-capture-output mpirun -n 2 pytest --only-mpi
+          conda run -n test_karabo --no-capture-output pytest --cov=./ --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,33 +50,36 @@ jobs:
           conda create -y -n test_karabo python=3.10
           conda env update -n test_karabo -f environment.yaml --prune
           conda install -y -n test_karabo pybind11 ipykernel
-          # Run tools via `conda run -n test_karabo` so they execute inside the
-          # env's Python 3.10 interpreter. `conda activate` is unreliable in the
-          # runner shell and silently falls back to system Python, which breaks
-          # type checking (dask/xarray missing -> spurious mypy errors).
-          conda run -n test_karabo --no-capture-output \
-            python -m ipykernel install --user --name python3.10
-          conda run -n test_karabo --no-capture-output pip install -e ".[dev]"
+          # Address the env by the absolute path to its interpreter. `conda
+          # activate` / `conda run -n` proved unreliable on the runner: they
+          # silently resolved to a different Python, so dev tools were installed
+          # into the wrong environment and mypy then ran against an interpreter
+          # without typed dask/xarray, producing spurious type errors.
+          PY="$CONDA/envs/test_karabo/bin/python"
+          "$PY" -m ipykernel install --user --name python3.10
+          "$PY" -m pip install -e ".[dev]"
 
           # Debug since we had problems with mpi installation
-          conda run -n test_karabo --no-capture-output python -c "import h5py; print('h5py ok')"
+          "$PY" -c "import h5py; print('h5py ok')"
           which wsclean || true
           ldd "$(which wsclean)" | grep -i mpi || true
 
       - name: Test Dev-Tools
         shell: bash -el {0}
         run: |
-          conda run -n test_karabo --no-capture-output flake8 .
-          conda run -n test_karabo --no-capture-output black --check .
-          conda run -n test_karabo --no-capture-output isort --check .
-          conda run -n test_karabo --no-capture-output mypy .
+          PY="$CONDA/envs/test_karabo/bin/python"
+          "$PY" -m flake8 .
+          "$PY" -m black --check .
+          "$PY" -m isort --check .
+          "$PY" -m mypy .
 
       - name: Test Code
         shell: bash -el {0}
         run: |
           export IS_GITHUB_RUNNER=true RUN_GPU_TESTS=false RUN_NOTEBOOK_TESTS=true
-          conda run -n test_karabo --no-capture-output mpirun -n 2 pytest --only-mpi
-          conda run -n test_karabo --no-capture-output pytest --cov=./ --cov-report=xml
+          PY="$CONDA/envs/test_karabo/bin/python"
+          "$CONDA/envs/test_karabo/bin/mpirun" -n 2 "$PY" -m pytest --only-mpi
+          "$PY" -m pytest --cov=./ --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
The `conda activate test_karabo` calls were unreliable in the runner shell and silently fell back to the system Python 3.12, where dask/xarray are not installed. That made mypy emit spurious unused-ignore/no-any-return/ arg-type errors and broke the nightly build. Invoke every tool through `conda run -n test_karabo` so they always execute in the env's Python 3.10 interpreter. Also target `conda install` at the env explicitly and fix a `tru` -> `true` typo in the wsclean debug line.

 :white_check_mark: