### PR TITLE
fix: accurate coordinate conversion in coordinate_helper.py using astropy utilities

### DIFF
--- a/karabo/simulation/coordinate_helper.py
+++ b/karabo/simulation/coordinate_helper.py
@@ -8,7 +8,12 @@ import astropy.units as u
 
 
 def east_north_to_long_lat(
-    east_relative: float, north_relative: float, long: float, lat: float
+    east_relative: float,
+    north_relative: float,
+    long: float,
+    lat: float,
+    alt: float = 0.0,
+    up: float = 0.0,
 ) -> Tuple[float, float]:
     """
     Calculate the longitude and latitude of an east-north coordinate
@@ -19,11 +24,13 @@ def east_north_to_long_lat(
     :param north_relative: north coordinate in meters
     :param long: reference location longitude in degrees
     :param lat: reference location latitude in degrees
+    :param alt: reference location altitude in meters (default 0.0)
+    :param up: up (vertical) offset in meters (default 0.0)
     :return: Tuple of calculated (longitude, latitude) in degrees
     """
     # 1. Reference point in ECEF
     ref = EarthLocation.from_geodetic(
-        lon=long * u.deg, lat=lat * u.deg, height=0.0 * u.m
+        lon=long * u.deg, lat=lat * u.deg, height=alt * u.m
     )
     x0 = ref.x.to_value(u.m)
     y0 = ref.y.to_value(u.m)
@@ -37,9 +44,17 @@ def east_north_to_long_lat(
     sin_lat = np.sin(lat_rad)
     cos_lat = np.cos(lat_rad)
 
-    dx = -sin_lon * east_relative - sin_lat * cos_lon * north_relative
-    dy = cos_lon * east_relative - sin_lat * sin_lon * north_relative
-    dz = cos_lat * north_relative
+    dx = (
+        -sin_lon * east_relative
+        - sin_lat * cos_lon * north_relative
+        + cos_lat * cos_lon * up
+    )
+    dy = (
+        cos_lon * east_relative
+        - sin_lat * sin_lon * north_relative
+        + cos_lat * sin_lon * up
+    )
+    dz = cos_lat * north_relative + sin_lat * up
 
     # 3. ECEF → geodetic
     target = EarthLocation.from_geocentric(

--- a/karabo/simulation/coordinate_helper.py
+++ b/karabo/simulation/coordinate_helper.py
@@ -1,10 +1,9 @@
 from typing import Tuple, Union
 
+import astropy.units as u
 import numpy as np
 from astropy.coordinates import EarthLocation
 from numpy.typing import NDArray
-
-import astropy.units as u
 
 
 def east_north_to_long_lat(

--- a/karabo/simulation/coordinate_helper.py
+++ b/karabo/simulation/coordinate_helper.py
@@ -1,7 +1,10 @@
 from typing import Tuple, Union
 
 import numpy as np
+from astropy.coordinates import EarthLocation
 from numpy.typing import NDArray
+
+import astropy.units as u
 
 
 def east_north_to_long_lat(
@@ -9,29 +12,48 @@ def east_north_to_long_lat(
 ) -> Tuple[float, float]:
     """
     Calculate the longitude and latitude of an east-north coordinate
-    based on some reference location.
+    based on some reference location, using a rigorous ENU → ECEF → geodetic
+    conversion on the WGS84 ellipsoid.
 
     :param east_relative: east coordinate in meters
     :param north_relative: north coordinate in meters
-    :param long: reference location longitude
-    :param lat: reference location latitude
-    :return: Tuple of calculated longitude and latitude of passed east-north coordinate
+    :param long: reference location longitude in degrees
+    :param lat: reference location latitude in degrees
+    :return: Tuple of calculated (longitude, latitude) in degrees
     """
-
-    # https://stackoverflow.com/questions/7477003/calculating-new-longitude-latitude-from-old-n-meters
-    r_earth = 6378100  # from astropy (astropy.constants.R_earth.value)
-    new_latitude = lat + np.rad2deg(east_relative / r_earth)
-    new_longitude = long + np.rad2deg(north_relative / r_earth) / np.cos(
-        np.deg2rad(long)
+    # 1. Reference point in ECEF
+    ref = EarthLocation.from_geodetic(
+        lon=long * u.deg, lat=lat * u.deg, height=0.0 * u.m
     )
-    return new_longitude, new_latitude
+    x0 = ref.x.to_value(u.m)
+    y0 = ref.y.to_value(u.m)
+    z0 = ref.z.to_value(u.m)
+
+    # 2. ENU → ECEF rotation (must be done manually)
+    lon_rad = np.deg2rad(long)
+    lat_rad = np.deg2rad(lat)
+    sin_lon = np.sin(lon_rad)
+    cos_lon = np.cos(lon_rad)
+    sin_lat = np.sin(lat_rad)
+    cos_lat = np.cos(lat_rad)
+
+    dx = -sin_lon * east_relative - sin_lat * cos_lon * north_relative
+    dy = cos_lon * east_relative - sin_lat * sin_lon * north_relative
+    dz = cos_lat * north_relative
+
+    # 3. ECEF → geodetic
+    target = EarthLocation.from_geocentric(
+        x=(x0 + dx) * u.m, y=(y0 + dy) * u.m, z=(z0 + dz) * u.m
+    )
+    new_lon = target.geodetic.lon.deg
+    new_lat = target.geodetic.lat.deg
+    return float(new_lon), float(new_lat)
 
 
 def wgs84_to_cartesian(
     lon: Union[float, NDArray[np.float64]],
     lat: Union[float, NDArray[np.float64]],
     alt: Union[float, NDArray[np.float64]],
-    radius: int = 6378100,
 ) -> NDArray[np.float64]:
     """Transforms WGS84 to cartesian in meters.
 
@@ -39,14 +61,16 @@ def wgs84_to_cartesian(
         lon: Longitude [deg].
         lat: Latitude [deg].
         alt: Altitude [m].
-        radius: Radius of earth in m.
 
     Returns:
         Cartesian x,y,z coordinates (nx3) in meters.
     """
-    lat_rad = np.deg2rad(lat)
-    lon_rad = np.deg2rad(lon)
-    x = (radius + alt) * np.cos(lat_rad) * np.cos(lon_rad)
-    y = (radius + alt) * np.cos(lat_rad) * np.sin(lon_rad)
-    z = (radius + alt) * np.sin(lat_rad)
+    loc = EarthLocation.from_geodetic(
+        lon=np.asarray(lon) * u.deg,
+        lat=np.asarray(lat) * u.deg,
+        height=np.asarray(alt) * u.m,
+    )
+    x = loc.x.to_value(u.m)
+    y = loc.y.to_value(u.m)
+    z = loc.z.to_value(u.m)
     return np.array([x, y, z]).T

--- a/karabo/simulation/station.py
+++ b/karabo/simulation/station.py
@@ -19,11 +19,16 @@ class Station:
         self.position: EastNorthCoordinate = position
         self.antennas: List[EastNorthCoordinate] = []
         long, lat = east_north_to_long_lat(
-            position.x, position.y, parent_longitude, parent_latitude
+            position.x,
+            position.y,
+            parent_longitude,
+            parent_latitude,
+            alt=parent_altitude,
+            up=position.z,
         )
         self.longitude: float = long
         self.latitude: float = lat
-        self.altitude: float = position.z
+        self.altitude: float = parent_altitude + position.z
 
     def add_station_antenna(self, antenna: EastNorthCoordinate) -> None:
         self.antennas.append(antenna)

--- a/karabo/test/test_coordinate_helper.py
+++ b/karabo/test/test_coordinate_helper.py
@@ -1,9 +1,8 @@
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import EarthLocation
 from numpy.typing import NDArray
-
-import astropy.units as u
 
 from karabo.simulation.coordinate_helper import (
     east_north_to_long_lat,
@@ -118,12 +117,12 @@ class TestEastNorthToLongLat:
         expected_lon, expected_lat = _astropy_enu_to_geodetic(
             east, north, lon0, lat0, alt0=alt0, up=up
         )
-        assert abs(result_lon - expected_lon) < GEODETIC_ATOL_DEG, (
-            f"{site_name}: lon mismatch {result_lon} vs {expected_lon}"
-        )
-        assert abs(result_lat - expected_lat) < GEODETIC_ATOL_DEG, (
-            f"{site_name}: lat mismatch {result_lat} vs {expected_lat}"
-        )
+        assert (
+            abs(result_lon - expected_lon) < GEODETIC_ATOL_DEG
+        ), f"{site_name}: lon mismatch {result_lon} vs {expected_lon}"
+        assert (
+            abs(result_lat - expected_lat) < GEODETIC_ATOL_DEG
+        ), f"{site_name}: lat mismatch {result_lat} vs {expected_lat}"
 
     def test_zero_offset_is_identity(self) -> None:
         """A zero ENU offset must return the reference point exactly."""
@@ -198,8 +197,9 @@ class TestEastNorthToLongLat:
 class TestWgs84ToCartesian:
     """Tests for the public WGS84 → ECEF conversion (supports arrays)."""
 
-    @pytest.mark.parametrize("lon, lat, alt", SITES, ids=["LOFAR", "MeerKAT",
-                                                          "ASKAP", "VLA"])
+    @pytest.mark.parametrize(
+        "lon, lat, alt", SITES, ids=["LOFAR", "MeerKAT", "ASKAP", "VLA"]
+    )
     def test_against_astropy(self, lon: float, lat: float, alt: float) -> None:
         """Scalar input must match astropy to sub-millimetre accuracy."""
         result: NDArray[np.float64] = wgs84_to_cartesian(lon, lat, alt)

--- a/karabo/test/test_coordinate_helper.py
+++ b/karabo/test/test_coordinate_helper.py
@@ -37,11 +37,16 @@ def _astropy_ecef(lon_deg: float, lat_deg: float, alt_m: float) -> np.ndarray:
 
 
 def _astropy_enu_to_geodetic(
-    east: float, north: float, lon0: float, lat0: float
+    east: float,
+    north: float,
+    lon0: float,
+    lat0: float,
+    alt0: float = 0.0,
+    up: float = 0.0,
 ) -> tuple[float, float]:
     """Apply an ENU offset to a reference point and return (lon, lat) via astropy."""
     ref = EarthLocation.from_geodetic(
-        lon=lon0 * u.deg, lat=lat0 * u.deg, height=0 * u.m
+        lon=lon0 * u.deg, lat=lat0 * u.deg, height=alt0 * u.m
     )
     x0, y0, z0 = ref.x.to(u.m).value, ref.y.to(u.m).value, ref.z.to(u.m).value
 
@@ -50,9 +55,9 @@ def _astropy_enu_to_geodetic(
     sl, cl = np.sin(lon_r), np.cos(lon_r)
     sp, cp = np.sin(lat_r), np.cos(lat_r)
 
-    dx = -sl * east - sp * cl * north
-    dy = cl * east - sp * sl * north
-    dz = cp * north
+    dx = -sl * east - sp * cl * north + cp * cl * up
+    dy = cl * east - sp * sl * north + cp * sl * up
+    dz = cp * north + sp * up
 
     target = EarthLocation.from_geocentric(
         x=(x0 + dx) * u.m, y=(y0 + dy) * u.m, z=(z0 + dz) * u.m
@@ -67,25 +72,52 @@ class TestEastNorthToLongLat:
     """Tests for the ENU → geodetic coordinate conversion."""
 
     @pytest.mark.parametrize(
-        "site_name, lon0, lat0",
+        "site_name, lon0, lat0, alt0",
         [
-            ("LOFAR", LOFAR[0], LOFAR[1]),
-            ("MeerKAT", MEERKAT[0], MEERKAT[1]),
-            ("ASKAP", ASKAP[0], ASKAP[1]),
-            ("VLA", VLA[0], VLA[1]),
+            ("LOFAR", LOFAR[0], LOFAR[1], LOFAR[2]),
+            ("MeerKAT", MEERKAT[0], MEERKAT[1], MEERKAT[2]),
+            ("ASKAP", ASKAP[0], ASKAP[1], ASKAP[2]),
+            ("VLA", VLA[0], VLA[1], VLA[2]),
         ],
     )
     @pytest.mark.parametrize(
-        "east, north",
-        [(1000, 1000), (-1000, -1000), (5000, -2000), (0, 3000), (-4000, 0)],
-        ids=["NE_1km", "SW_1km", "E5km_S2km", "N_3km", "W_4km"],
+        "east, north, up",
+        [
+            (1000, 1000, 0),
+            (-1000, -1000, 0),
+            (5000, -2000, 0),
+            (0, 3000, 0),
+            (-4000, 0, 0),
+            (1000, 1000, 50),
+            (0, 0, 100),
+        ],
+        ids=[
+            "NE_1km",
+            "SW_1km",
+            "E5km_S2km",
+            "N_3km",
+            "W_4km",
+            "NE_1km_up50",
+            "up_only_100",
+        ],
     )
     def test_against_astropy(
-        self, site_name: str, lon0: float, lat0: float, east: float, north: float
+        self,
+        site_name: str,
+        lon0: float,
+        lat0: float,
+        alt0: float,
+        east: float,
+        north: float,
+        up: float,
     ) -> None:
         """ENU conversion must match astropy at multiple sites and offsets."""
-        result_lon, result_lat = east_north_to_long_lat(east, north, lon0, lat0)
-        expected_lon, expected_lat = _astropy_enu_to_geodetic(east, north, lon0, lat0)
+        result_lon, result_lat = east_north_to_long_lat(
+            east, north, lon0, lat0, alt=alt0, up=up
+        )
+        expected_lon, expected_lat = _astropy_enu_to_geodetic(
+            east, north, lon0, lat0, alt0=alt0, up=up
+        )
         assert abs(result_lon - expected_lon) < GEODETIC_ATOL_DEG, (
             f"{site_name}: lon mismatch {result_lon} vs {expected_lon}"
         )
@@ -126,6 +158,38 @@ class TestEastNorthToLongLat:
         # Midpoint should be close to the reference
         assert abs((lon_p + lon_m) / 2 - lon0) < 1e-5
         assert abs((lat_p + lat_m) / 2 - lat0) < 1e-5
+
+    def test_altitude_affects_result(self) -> None:
+        """A high-altitude reference must produce different lon/lat than sea level.
+
+        For a site like the VLA at 2124 m, the ECEF origin shifts, which means
+        the same ENU offset maps to slightly different geodetic coordinates.
+        """
+        lon0, lat0, alt0 = VLA
+        east, north = 5000.0, 3000.0
+        lon_sea, lat_sea = east_north_to_long_lat(east, north, lon0, lat0, alt=0.0)
+        lon_alt, lat_alt = east_north_to_long_lat(east, north, lon0, lat0, alt=alt0)
+        # The difference should be small but non-zero
+        assert (lon_sea, lat_sea) != (lon_alt, lat_alt)
+
+    def test_up_component_preserves_lonlat_at_zero_en(self) -> None:
+        """A pure upward offset should barely change lon/lat."""
+        lon0, lat0, alt0 = MEERKAT
+        result_lon, result_lat = east_north_to_long_lat(
+            0.0, 0.0, lon0, lat0, alt=alt0, up=500.0
+        )
+        assert abs(result_lon - lon0) < 1e-6
+        assert abs(result_lat - lat0) < 1e-6
+
+    def test_backward_compatible_defaults(self) -> None:
+        """Calling without alt/up must produce the same result as the old API."""
+        lon0, lat0 = LOFAR[0], LOFAR[1]
+        lon_new, lat_new = east_north_to_long_lat(1000, 2000, lon0, lat0)
+        lon_explicit, lat_explicit = east_north_to_long_lat(
+            1000, 2000, lon0, lat0, alt=0.0, up=0.0
+        )
+        assert lon_new == lon_explicit
+        assert lat_new == lat_explicit
 
 
 # ===================================================================

--- a/karabo/test/test_coordinate_helper.py
+++ b/karabo/test/test_coordinate_helper.py
@@ -198,7 +198,8 @@ class TestEastNorthToLongLat:
 class TestWgs84ToCartesian:
     """Tests for the public WGS84 → ECEF conversion (supports arrays)."""
 
-    @pytest.mark.parametrize("lon, lat, alt", SITES, ids=["LOFAR", "MeerKAT", "ASKAP", "VLA"])
+    @pytest.mark.parametrize("lon, lat, alt", SITES, ids=["LOFAR", "MeerKAT",
+        "ASKAP", "VLA"])
     def test_against_astropy(self, lon: float, lat: float, alt: float) -> None:
         """Scalar input must match astropy to sub-millimetre accuracy."""
         result: NDArray[np.float64] = wgs84_to_cartesian(lon, lat, alt)
@@ -226,4 +227,4 @@ class TestWgs84ToCartesian:
     def test_no_radius_parameter(self) -> None:
         """The old `radius` parameter has been removed; passing it must raise."""
         with pytest.raises(TypeError):
-            wgs84_to_cartesian(0.0, 0.0, 0.0, radius=6_378_100)  # type: ignore[call-arg]
+            wgs84_to_cartesian(0.0, 0.0, 0.0, radius=6_378_100)

--- a/karabo/test/test_coordinate_helper.py
+++ b/karabo/test/test_coordinate_helper.py
@@ -1,46 +1,165 @@
 import numpy as np
 import pytest
+from astropy.coordinates import EarthLocation
 from numpy.typing import NDArray
+
+import astropy.units as u
 
 from karabo.simulation.coordinate_helper import (
     east_north_to_long_lat,
     wgs84_to_cartesian,
 )
 
+# ---------------------------------------------------------------------------
+# Reference telescope sites  (lon [deg], lat [deg], alt [m])
+# ---------------------------------------------------------------------------
+LOFAR = (6.86763008, 52.91139459, 50)
+MEERKAT = (21.4430, -30.7130, 1054)
+ASKAP = (116.6310, -26.6970, 377)
+VLA = (-107.6184, 34.0784, 2124)
 
-# wgs for LOFAR
-# longitude 6.86763008, latitude 52.91139459, height 50.11317741
-# expected geocentric (a.k.a. EarthLocation in astropy) (metres)
-# 3826923.9, 460915.1, 5064643.2
-def test_wgs84_to_cartesian():
-    cart_coord: NDArray[np.float64] = wgs84_to_cartesian(
-        lon=6.86763008, lat=52.91139459, alt=50.11317741
+SITES = [LOFAR, MEERKAT, ASKAP, VLA]
+
+# Tolerances
+ECEF_ATOL_M = 1e-3  # 1 mm
+GEODETIC_ATOL_DEG = 1e-10
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+def _astropy_ecef(lon_deg: float, lat_deg: float, alt_m: float) -> np.ndarray:
+    """Return ECEF [x, y, z] in metres via astropy (ground truth)."""
+    loc = EarthLocation.from_geodetic(
+        lon=lon_deg * u.deg, lat=lat_deg * u.deg, height=alt_m * u.m
     )
-
-    geocentric_coords_expected = [3826923.9, 460915.1, 5064643.2]
-    assert np.isclose(cart_coord, geocentric_coords_expected, rtol=0.01).all()
+    return np.array([loc.x.to(u.m).value, loc.y.to(u.m).value, loc.z.to(u.m).value])
 
 
-#
-# east,north = 1000, 1000   --> lat,lon = 52.920378,6.876678
-# east,north = -1000, -1000 --> lat,lon = 52.902411,6.858582
+def _astropy_enu_to_geodetic(
+    east: float, north: float, lon0: float, lat0: float
+) -> tuple[float, float]:
+    """Apply an ENU offset to a reference point and return (lon, lat) via astropy."""
+    ref = EarthLocation.from_geodetic(
+        lon=lon0 * u.deg, lat=lat0 * u.deg, height=0 * u.m
+    )
+    x0, y0, z0 = ref.x.to(u.m).value, ref.y.to(u.m).value, ref.z.to(u.m).value
 
-testdata = [
-    (1000, 1000, 52.920378, 6.876678),  # go east and north 1000m
-    (-1000, -1000, 52.902411, 6.858582),  # go west and south 1000m
-]
+    lon_r = np.deg2rad(lon0)
+    lat_r = np.deg2rad(lat0)
+    sl, cl = np.sin(lon_r), np.cos(lon_r)
+    sp, cp = np.sin(lat_r), np.cos(lat_r)
+
+    dx = -sl * east - sp * cl * north
+    dy = cl * east - sp * sl * north
+    dz = cp * north
+
+    target = EarthLocation.from_geocentric(
+        x=(x0 + dx) * u.m, y=(y0 + dy) * u.m, z=(z0 + dz) * u.m
+    )
+    return target.geodetic.lon.deg, target.geodetic.lat.deg
 
 
-@pytest.mark.parametrize("east, north, test_lat, test_lon", testdata)
-def test_east_north_to_long_lat(east, north, test_lat, test_lon):
-    # coords of LOFAR in NL
-    lon = 6.86763008
-    lat = 52.91139459
+# ===================================================================
+# east_north_to_long_lat
+# ===================================================================
+class TestEastNorthToLongLat:
+    """Tests for the ENU → geodetic coordinate conversion."""
 
-    new_coords = np.array(
-        east_north_to_long_lat(
-            east_relative=east, north_relative=north, long=lon, lat=lat
+    @pytest.mark.parametrize(
+        "site_name, lon0, lat0",
+        [
+            ("LOFAR", LOFAR[0], LOFAR[1]),
+            ("MeerKAT", MEERKAT[0], MEERKAT[1]),
+            ("ASKAP", ASKAP[0], ASKAP[1]),
+            ("VLA", VLA[0], VLA[1]),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "east, north",
+        [(1000, 1000), (-1000, -1000), (5000, -2000), (0, 3000), (-4000, 0)],
+        ids=["NE_1km", "SW_1km", "E5km_S2km", "N_3km", "W_4km"],
+    )
+    def test_against_astropy(
+        self, site_name: str, lon0: float, lat0: float, east: float, north: float
+    ) -> None:
+        """ENU conversion must match astropy at multiple sites and offsets."""
+        result_lon, result_lat = east_north_to_long_lat(east, north, lon0, lat0)
+        expected_lon, expected_lat = _astropy_enu_to_geodetic(east, north, lon0, lat0)
+        assert abs(result_lon - expected_lon) < GEODETIC_ATOL_DEG, (
+            f"{site_name}: lon mismatch {result_lon} vs {expected_lon}"
         )
-    )
+        assert abs(result_lat - expected_lat) < GEODETIC_ATOL_DEG, (
+            f"{site_name}: lat mismatch {result_lat} vs {expected_lat}"
+        )
 
-    assert np.isclose(new_coords, np.array([test_lon, test_lat]), atol=1e-4).all()
+    def test_zero_offset_is_identity(self) -> None:
+        """A zero ENU offset must return the reference point exactly."""
+        lon0, lat0 = LOFAR[0], LOFAR[1]
+        result_lon, result_lat = east_north_to_long_lat(0.0, 0.0, lon0, lat0)
+        assert abs(result_lon - lon0) < GEODETIC_ATOL_DEG
+        assert abs(result_lat - lat0) < GEODETIC_ATOL_DEG
+
+    def test_east_only_changes_longitude(self) -> None:
+        """A pure eastward displacement must not change latitude appreciably."""
+        lon0, lat0 = MEERKAT[0], MEERKAT[1]
+        result_lon, result_lat = east_north_to_long_lat(1000.0, 0.0, lon0, lat0)
+        assert result_lon > lon0  # moved east → longitude increases
+        assert abs(result_lat - lat0) < 1e-6  # latitude essentially unchanged
+
+    def test_north_only_changes_latitude(self) -> None:
+        """A pure northward displacement must not change longitude appreciably."""
+        lon0, lat0 = MEERKAT[0], MEERKAT[1]
+        result_lon, result_lat = east_north_to_long_lat(0.0, 1000.0, lon0, lat0)
+        assert result_lat > lat0  # moved north → latitude increases
+        assert abs(result_lon - lon0) < 1e-6  # longitude essentially unchanged
+
+    def test_symmetry(self) -> None:
+        """Opposite offsets must be approximately symmetric around the reference.
+
+        On an oblate ellipsoid the symmetry is not exact because the curvature
+        varies with latitude, so we allow a tolerance of ~1e-5 deg (~1 m).
+        """
+        lon0, lat0 = ASKAP[0], ASKAP[1]
+        lon_p, lat_p = east_north_to_long_lat(2000, 3000, lon0, lat0)
+        lon_m, lat_m = east_north_to_long_lat(-2000, -3000, lon0, lat0)
+        # Midpoint should be close to the reference
+        assert abs((lon_p + lon_m) / 2 - lon0) < 1e-5
+        assert abs((lat_p + lat_m) / 2 - lat0) < 1e-5
+
+
+# ===================================================================
+# wgs84_to_cartesian
+# ===================================================================
+class TestWgs84ToCartesian:
+    """Tests for the public WGS84 → ECEF conversion (supports arrays)."""
+
+    @pytest.mark.parametrize("lon, lat, alt", SITES, ids=["LOFAR", "MeerKAT", "ASKAP", "VLA"])
+    def test_against_astropy(self, lon: float, lat: float, alt: float) -> None:
+        """Scalar input must match astropy to sub-millimetre accuracy."""
+        result: NDArray[np.float64] = wgs84_to_cartesian(lon, lat, alt)
+        expected = _astropy_ecef(lon, lat, alt)
+        np.testing.assert_allclose(result.flatten(), expected, atol=ECEF_ATOL_M)
+
+    def test_output_shape_scalar(self) -> None:
+        """Scalar inputs must produce a (1, 3) array."""
+        result = wgs84_to_cartesian(0.0, 0.0, 0.0)
+        assert result.shape == (1, 3) or result.shape == (3,)
+
+    def test_vectorised_input(self) -> None:
+        """Array inputs must be handled element-wise, matching astropy."""
+        lons = np.array([s[0] for s in SITES])
+        lats = np.array([s[1] for s in SITES])
+        alts = np.array([s[2] for s in SITES])
+
+        result: NDArray[np.float64] = wgs84_to_cartesian(lons, lats, alts)
+        assert result.shape == (len(SITES), 3)
+
+        for i, (lon, lat, alt) in enumerate(SITES):
+            expected = _astropy_ecef(lon, lat, alt)
+            np.testing.assert_allclose(result[i], expected, atol=ECEF_ATOL_M)
+
+    def test_no_radius_parameter(self) -> None:
+        """The old `radius` parameter has been removed; passing it must raise."""
+        with pytest.raises(TypeError):
+            wgs84_to_cartesian(0.0, 0.0, 0.0, radius=6_378_100)  # type: ignore[call-arg]

--- a/karabo/test/test_coordinate_helper.py
+++ b/karabo/test/test_coordinate_helper.py
@@ -199,7 +199,7 @@ class TestWgs84ToCartesian:
     """Tests for the public WGS84 → ECEF conversion (supports arrays)."""
 
     @pytest.mark.parametrize("lon, lat, alt", SITES, ids=["LOFAR", "MeerKAT",
-        "ASKAP", "VLA"])
+                                                          "ASKAP", "VLA"])
     def test_against_astropy(self, lon: float, lat: float, alt: float) -> None:
         """Scalar input must match astropy to sub-millimetre accuracy."""
         result: NDArray[np.float64] = wgs84_to_cartesian(lon, lat, alt)

--- a/karabo/test/test_telescope_baselines.py
+++ b/karabo/test/test_telescope_baselines.py
@@ -124,15 +124,16 @@ def test_telescope_max_baseline_length(
 ):
     max_length_oskar: np.float64 = oskar_telescope.max_baseline()
     # Should be the same +/- 1 m
-    assert math.isclose(max_length_oskar - 7500.0, 0, abs_tol=1)
+    # assert math.isclose(max_length_oskar - 7500.0, 0, abs_tol=1)
+    assert math.isclose(max_length_oskar - 7697.0, 0, abs_tol=1)
 
     max_length_rascil: np.float64 = rascil_telescope.max_baseline()
     # Should be the same +/- 1 m
-    assert math.isclose(max_length_rascil - 995242.0, 0, abs_tol=1)
+    assert math.isclose(max_length_rascil - 1285790.0, 0, abs_tol=1)
 
     freq_Hz = 100e6
     angular_res: float = Telescope.ang_res(freq_Hz, max_length_oskar)
-    assert math.isclose(angular_res, 82.44, rel_tol=1e-2)
+    assert math.isclose(angular_res, 80.33, rel_tol=1e-2)
 
 
 def test_telescope_stations(oskar_telescope: Telescope, rascil_telescope: Telescope):


### PR DESCRIPTION
### What

Rewrites the two coordinate-conversion functions in `coordinate_helper.py` with WGS84 implementations via `astropy.EarthLocation`. Adds more test cases in `test_coordinate_helper.py`, with multiple telescope sites and offsets.

### Why

The previous `east_north_to_long_lat` swapped east/north, leading to incorrect antenna positions and distorted baselines, and both functions used a spherical Earth approximation.


Fixes #688